### PR TITLE
Added pyomo missing status codes

### DIFF
--- a/cornflow-dags/DAG/rostering/schemas/solution.json
+++ b/cornflow-dags/DAG/rostering/schemas/solution.json
@@ -37,7 +37,7 @@
       "description": "Indicators of solution",
       "show": true,
       "properties": {
-        "fo": {
+        "of": {
           "type": "number",
           "title": "F.O",
           "description": "Objective function"

--- a/libs/client/cornflow_client/constants.py
+++ b/libs/client/cornflow_client/constants.py
@@ -61,11 +61,14 @@ PYOMO_STOP_MAPPING = {
     "minFunctionValue": STATUS_UNDEFINED,
     "minStepLength": STATUS_UNDEFINED,
     "other": STATUS_UNDEFINED,
+    "intermediateNonInteger": STATUS_TIME_LIMIT,
+    "feasible": STATUS_TIME_LIMIT,
+    "noSolution": STATUS_TIME_LIMIT,
 }
 
 PYOMO_STATUS_MAPPING = {
     "ok": SOLUTION_STATUS_FEASIBLE,
-    "warning": SOLUTION_STATUS_FEASIBLE,
+    "warning": SOLUTION_STATUS_INFEASIBLE,
     "error": SOLUTION_STATUS_INFEASIBLE,
     "aborted": SOLUTION_STATUS_INFEASIBLE,
     "unknown": SOLUTION_STATUS_INFEASIBLE,


### PR DESCRIPTION
- Added missing pyomos termination condition status. Those do not appear in pyomo documentation but they can be returned.
- When pyomo returns a warning, it means that there was no error but the problem could not be solved. See [here](https://github.com/Pyomo/pyomo/blob/d143fb484f1abbbdd7f156d60a49b13524244c5f/pyomo/opt/results/solver.py#L86): pyomo returns a warning when no solution is found or when the problem is infeasible. So the associated cornflow solution status should be SOLUTION_STATUS_INFEASIBLE