### PR TITLE
find dn from ldap instead build from env var

### DIFF
--- a/.github/workflows/test_cornflow_core.yml
+++ b/.github/workflows/test_cornflow_core.yml
@@ -43,6 +43,7 @@ jobs:
       run: |
         coverage run --source=./cornflow_core/ --omit="*/tests/*" -m unittest discover -s cornflow_core/tests 
         coverage report -m
+        coverage xml
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v3
       with:

--- a/libs/core/setup.py
+++ b/libs/core/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="cornflow-core",
-    version="0.1.2",
+    version="0.1.3",
     author="baobab soluciones",
     author_email="sistemas@baobabsoluciones.es",
     description="REST API flask backend components used by cornflow and other REST APIs",


### PR DESCRIPTION
Now we can find the complete dn from ldap server instead of build from environment vars. Changes allow to authenticate users even if they are from different groups in the organization.