### PR TITLE
Bump gevent version

### DIFF
--- a/cornflow-server/Dockerfile
+++ b/cornflow-server/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # CORNFLOW vars
-ARG CORNFLOW_VERSION=1.0.5
+ARG CORNFLOW_VERSION=1.0.6
 
 # install linux pkg
 RUN apt update -y && apt-get install -y --no-install-recommends \

--- a/cornflow-server/changelog.rst
+++ b/cornflow-server/changelog.rst
@@ -1,3 +1,11 @@
+version 1.0.6
+--------------
+
+- released: 2023-10-03
+- description: security version of cornflow to update vulnerability on dependency
+- changelog:
+    - updated version of gevent to 23.9.0.post1 due to security reasons.
+
 version 1.0.5
 --------------
 

--- a/cornflow-server/requirements.txt
+++ b/cornflow-server/requirements.txt
@@ -13,7 +13,7 @@ flask-inflate<=0.3
 Flask-Migrate<=4.0.4
 Flask-RESTful<=0.3.9
 Flask-SQLAlchemy==2.5.1
-gevent<=22.10.2
+gevent==23.9.0.post1
 greenlet<=2.0.2
 gunicorn<=20.1.0
 jsonpatch<=1.32

--- a/cornflow-server/requirements.txt
+++ b/cornflow-server/requirements.txt
@@ -13,7 +13,7 @@ flask-inflate<=0.3
 Flask-Migrate<=4.0.4
 Flask-RESTful<=0.3.9
 Flask-SQLAlchemy==2.5.1
-gevent==23.9.0.post1
+gevent==23.9.1
 greenlet<=2.0.2
 gunicorn<=20.1.0
 jsonpatch<=1.32

--- a/cornflow-server/setup.py
+++ b/cornflow-server/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="cornflow",
-    version="1.0.5",
+    version="1.0.6",
     author="baobab soluciones",
     author_email="cornflow@baobabsoluciones.es",
     description="Cornflow is an open source multi-solver optimization server with a REST API built using flask.",


### PR DESCRIPTION
This should fix the vulnerability reported.
We should try to update to version 23.9.1 but that also requires a bump in greenlet versions that I do not know the implications of. Will try to review later this week.