### PR TITLE
Now responses go back in the intended order instead of in alphabetical order

### DIFF
--- a/cornflow-server/cornflow/app.py
+++ b/cornflow-server/cornflow/app.py
@@ -49,6 +49,7 @@ def create_app(env_name="development", dataconn=None):
     dictConfig(log_config(app_config[env_name].LOG_LEVEL))
 
     app = Flask(__name__)
+    app.json.sort_keys = False
     app.logger.setLevel(app_config[env_name].LOG_LEVEL)
 
     app.config.from_object(app_config[env_name])


### PR DESCRIPTION
Json response are not sorted alphabetically and should go with the order in the original dict