### PR TITLE
Feature/af from docker base

### DIFF
--- a/cornflow-server/airflow_config/Dockerfile
+++ b/cornflow-server/airflow_config/Dockerfile
@@ -1,8 +1,8 @@
 # VERSION 2.7.1
 # AUTHOR: cornflow@baobabsoluciones.es
-# DESCRIPTION: Airflow 2.7.1 image personalized for use with Cornflow (from puckel/docker-airflow https://github.com/puckel/docker-airflow by "Puckel_")
+# DESCRIPTION: Airflow 2.7.1 image personalized for use with Cornflow (from baobabsoluciones/pysolver image)
 
-FROM python:3.10-slim-buster
+FROM baobabsoluciones/pysolver:1.0
 LABEL maintainer="cornflow@baobabsoluciones"
 
 # Never prompt the user for choices on installation/configuration of packages
@@ -16,45 +16,8 @@ ARG CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints
 ARG AIRFLOW__CORE__LOAD_EXAMPLES=False
 ENV AIRFLOW_HOME=${AIRFLOW_USER_HOME}
 
-# install Airflow requirements
-RUN apt update -y && apt-get install -y --no-install-recommends \
-        apt-utils \
-        default-jre \
-        default-jdk \
-        g++ \
-        gcc \
-        git \
-		freetds-bin \
-        krb5-user \
-        ldap-utils \
-        libffi6 \
-        libffi-dev \
-        libldap2-dev \
-		libpq-dev \
-        libprotobuf-dev \
-        libsasl2-2 \
-        libsasl2-dev \
-        libsasl2-modules \
-        libssl1.1 \
-        libssl-dev \
-        locales  \
-        lsb-release \
-        make \
-        pkg-config \
-        protobuf-compiler \
-		python3-dev \
-        sasl2-bin \
-        slapd \
-        sqlite3 \
-        ssh \
-        unixodbc \
-        wget
-
 # install Airflow and extras: celery,postgres and redis
 RUN pip install "apache-airflow[celery,google,postgres,redis,sendgrid]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
-RUN pip install python-ldap
-RUN pip install GitPython
-RUN pip install cmake
 
 # copy init script and config to container
 COPY scripts ${AIRFLOW_HOME}/scripts
@@ -64,20 +27,13 @@ COPY webserver_ldap.py ${AIRFLOW_HOME}/webserver_ldap.py
 # create folder for custom ssh keys
 RUN mkdir ${AIRFLOW_HOME}/.ssh
 
-# user airflow on application
-RUN useradd -ms /bin/bash -d ${AIRFLOW_HOME} airflow
-RUN chown -R airflow: ${AIRFLOW_HOME}
-
-# execute installation solvers script
-RUN python ${AIRFLOW_HOME}/scripts/solver_installation.py
-ENV GUROBI_HOME=${AIRFLOW_HOME}/gurobi/linux64
-ENV PATH=${PATH}:${GUROBI_HOME}/bin
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GUROBI_HOME}/lib
-ENV GRB_LICENSE_FILE=${AIRFLOW_HOME}/gurobi.lic
+# rights for user cornflow on application
+RUN chown -R cornflow: ${AIRFLOW_HOME}
 
 EXPOSE 8080 5555 8793
 
-USER airflow
+# change user to cornflow
+USER cornflow
 WORKDIR ${AIRFLOW_HOME}
 
 ENTRYPOINT ["python", "scripts/init_airflow_service.py"]

--- a/cornflow-server/airflow_config/Dockerfile.base
+++ b/cornflow-server/airflow_config/Dockerfile.base
@@ -1,0 +1,66 @@
+# VERSION 1.0
+# AUTHOR: cornflow@baobabsoluciones.es
+
+FROM python:3.10-slim-buster
+LABEL maintainer="cornflow@baobabsoluciones"
+
+# Never prompt the user for choices on installation/configuration of packages
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM linux
+
+# solver vars
+ENV SOLVER_DIR=/usr/local/solvers
+
+# install linux requirements
+RUN apt update -y && apt-get install -y --no-install-recommends \
+        apt-utils \
+        default-jre \
+        default-jdk \
+        g++ \
+        gcc \
+        git \
+		freetds-bin \
+        krb5-user \
+        ldap-utils \
+        libffi6 \
+        libffi-dev \
+        libldap2-dev \
+		libpq-dev \
+        libprotobuf-dev \
+        libsasl2-2 \
+        libsasl2-dev \
+        libsasl2-modules \
+        libssl1.1 \
+        libssl-dev \
+        locales  \
+        lsb-release \
+        make \
+        pkg-config \
+        protobuf-compiler \
+		python3-dev \
+        sasl2-bin \
+        slapd \
+        sqlite3 \
+        ssh \
+        unixodbc \
+        wget
+
+RUN pip install python-ldap
+RUN pip install GitPython
+RUN pip install cmake
+
+# copy init script and config to container
+COPY scripts ${SOLVER_DIR}/scripts
+
+# add user cornflow on application
+RUN useradd -ms /bin/bash -d ${SOLVER_DIR} cornflow
+RUN chown -R cornflow: ${SOLVER_DIR}
+
+# execute installation solvers script
+RUN python ${SOLVER_DIR}/scripts/solver_installation.py
+ENV GUROBI_HOME=${SOLVER_DIR}/gurobi/linux64
+ENV PATH=${PATH}:${GUROBI_HOME}/bin
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GUROBI_HOME}/lib
+ENV GRB_LICENSE_FILE=${GUROBI_HOME}/gurobi.lic
+
+WORKDIR ${SOLVER_DIR}

--- a/cornflow-server/airflow_config/scripts/solver_installation.py
+++ b/cornflow-server/airflow_config/scripts/solver_installation.py
@@ -8,11 +8,11 @@ from solvers import get_cbc, get_glpk, get_highs, get_choco, get_mipcl, get_guro
 # * MIPCL: https://github.com/onebitbrain/MIPCL/blob/master/bin/mps_mipcl
 # * glpk: https://www.gnu.org/software/glpk/
 # * Gurobi optimizer: https://www.gurobi.com/
-available_solver = ["HiGHS", "CBC", "CHOCO", "glpk", "gurobi"]
+available_solver = "HiGHS,CBC,CHOCO,glpk,gurobi"
+default_solvers = "HiGHS,CBC,gurobi"
 
 # list of solvers that will be installed
-solver_list = os.getenv("SOLVER_LIST", "CBC,glpk,HiGHS,CHOCO,MIPCL,gurobi").split(",")
-
+solver_list = os.getenv("SOLVER_LIST", default_solvers).split(",")
 
 def install(s):
     if s in "CBC":

--- a/cornflow-server/airflow_config/scripts/solvers/get_choco.py
+++ b/cornflow-server/airflow_config/scripts/solvers/get_choco.py
@@ -30,7 +30,7 @@ def install():
         )
         output_choco = choco_install.stdout
         print(output_choco)
-        uid = pwd.getpwnam("airflow").pw_uid
+        uid = pwd.getpwnam("cornflow").pw_uid
         gid = grp.getgrnam("root").gr_gid
         choco_path = "/usr/local/bin/choco.jar"
         os.chown(choco_path, uid, gid)

--- a/cornflow-server/airflow_config/scripts/solvers/get_gurobi.py
+++ b/cornflow-server/airflow_config/scripts/solvers/get_gurobi.py
@@ -19,15 +19,16 @@ def install():
 
     try:
 
-        install_dir = "/usr/local/airflow/gurobi"
-        os.chdir("/usr/local/airflow")
+        solver_dir = os.getenv("SOLVER_DIR")
+        install_dir = solver_dir+"/gurobi"
+        os.chdir(solver_dir)
         subprocess.check_output(
             ["wget", "https://packages.gurobi.com/10.0/gurobi10.0.1_linux64.tar.gz"]
         )
         subprocess.check_output(["tar", "-xvf", "gurobi10.0.1_linux64.tar.gz"])
         os.rename("gurobi1001", "gurobi")
-        uid = pwd.getpwnam("airflow").pw_uid
-        gid = grp.getgrnam("airflow").gr_gid
+        uid = pwd.getpwnam("cornflow").pw_uid
+        gid = grp.getgrnam("cornflow").gr_gid
         os.chown(install_dir, uid, gid)
         os.chdir(f"{install_dir}/linux64")
         gurobi_install = subprocess.run(

--- a/cornflow-server/airflow_config/scripts/solvers/get_highs.py
+++ b/cornflow-server/airflow_config/scripts/solvers/get_highs.py
@@ -29,7 +29,7 @@ def install():
         subprocess.check_output("make")
         subprocess.check_output(["cp", "bin/highs", "/usr/local/bin/highs"])
         subprocess.check_output(["chmod", "+x", "/usr/local/bin/highs"])
-        uid = pwd.getpwnam("airflow").pw_uid
+        uid = pwd.getpwnam("cornflow").pw_uid
         gid = grp.getgrnam("root").gr_gid
         highs_path = "/usr/local/bin/highs"
         os.chown(highs_path, uid, gid)

--- a/cornflow-server/airflow_config/scripts/solvers/get_mipcl.py
+++ b/cornflow-server/airflow_config/scripts/solvers/get_mipcl.py
@@ -25,7 +25,7 @@ def install():
         os.chdir(f"{MIPCL.working_dir}/bin")
         subprocess.check_output(["cp", "mps_mipcl", "/usr/local/bin/mps_mipcl"])
         subprocess.check_output(["chmod", "+x", "/usr/local/bin/mps_mipcl"])
-        uid = pwd.getpwnam("airflow").pw_uid
+        uid = pwd.getpwnam("cornflow").pw_uid
         gid = grp.getgrnam("root").gr_gid
         mips_path = "/usr/local/bin/mps_mipcl"
         os.chown(mips_path, uid, gid)


### PR DESCRIPTION
I have separated the airflow image and now we start from another python base plus the installation of dependencies and solvers. 
It is necessary to build an image in the hub from cornflow-server/airflow_config/Dockerfile.base with the tag baobabsoluciones/pysolver:1.0 before build airflow image from cornflow-server/airflow_config/Dockerfile.
The list of solvers to install has been reduced and now by default it will have: cbc, highs and gurobi.