### PR TITLE
fix add and config ssh key into user home dir

### DIFF
--- a/cornflow-server/airflow_config/Dockerfile
+++ b/cornflow-server/airflow_config/Dockerfile
@@ -26,7 +26,7 @@ COPY plugins ${AIRFLOW_HOME}/plugins
 COPY webserver_ldap.py ${AIRFLOW_HOME}/webserver_ldap.py
 
 # create folder for custom ssh keys
-RUN mkdir ${AIRFLOW_HOME}/.ssh
+RUN mkdir ${HOME}/.ssh
 
 # rights for user cornflow on application
 RUN chown -R cornflow: ${AIRFLOW_HOME}

--- a/cornflow-server/airflow_config/scripts/init_airflow_service.py
+++ b/cornflow-server/airflow_config/scripts/init_airflow_service.py
@@ -49,11 +49,11 @@ os.environ["AIRFLOW__CORE__EXECUTOR"] = f"{AIRFLOW__CORE__EXECUTOR}Executor"
 
 # Add ssh key for install packages inside workers
 CUSTOM_SSH_HOST = os.getenv("CUSTOM_SSH_HOST")
-if os.path.isfile("/usr/local/airflow/.ssh/id_rsa") and CUSTOM_SSH_HOST is not None:
-    ADD_KEY = "chmod 0600 /usr/local/airflow/.ssh/id_rsa && ssh-add /usr/local/airflow/.ssh/id_rsa"
-    ADD_HOST = f"ssh-keyscan {CUSTOM_SSH_HOST} >> /usr/local/airflow/.ssh/known_hosts"
-    CONFIG_SSH_HOST = f"echo Host {CUSTOM_SSH_HOST} > /usr/local/airflow/.ssh/config"
-    CONFIG_SSH_KEY = 'echo "    IdentityFile /usr/local/airflow/.ssh/id_rsa" >> /usr/local/airflow/.ssh/config'
+if os.path.isfile("$HOME/.ssh/id_rsa") and CUSTOM_SSH_HOST is not None:
+    ADD_KEY = "chmod 0600 $HOME/.ssh/id_rsa && ssh-add $HOME/.ssh/id_rsa"
+    ADD_HOST = f"ssh-keyscan {CUSTOM_SSH_HOST} >> $HOME/.ssh/known_hosts"
+    CONFIG_SSH_HOST = f"echo Host {CUSTOM_SSH_HOST} > $HOME/.ssh/config"
+    CONFIG_SSH_KEY = 'echo "    IdentityFile $HOME/.ssh/id_rsa" >> $HOME/.ssh/config'
     os.system(ADD_KEY)
     os.system(ADD_HOST)
     os.system(CONFIG_SSH_HOST)


### PR DESCRIPTION
The problem is that the user directory of the solvers image is not the same as where the ssh key was added and configured to install dependencies from private repositories.

Now we have to use as reference in airflow Dockerfile the `${HOME}/.ssh` directory and not `$AIRFLOW_HOME/.ssh` directory