### PR TITLE
Enhance authentication and configuration handling

### DIFF
--- a/cornflow-server/cornflow/config.py
+++ b/cornflow-server/cornflow/config.py
@@ -5,6 +5,10 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 
 
 class DefaultConfig(object):
+    """
+    Default configuration class
+    """
+
     SERVICE_NAME = os.getenv("SERVICE_NAME", "Cornflow")
     SECRET_TOKEN_KEY = os.getenv("SECRET_KEY")
     SECRET_BI_KEY = os.getenv("SECRET_BI_KEY")
@@ -21,6 +25,11 @@ class DefaultConfig(object):
     LOG_LEVEL = int(os.getenv("LOG_LEVEL", 20))
     SIGNUP_ACTIVATED = int(os.getenv("SIGNUP_ACTIVATED", 1))
     CORNFLOW_SERVICE_USER = os.getenv("CORNFLOW_SERVICE_USER", "service_user")
+
+    # If service user is allow to log with username and password
+    SERVICE_USER_ALLOW_PASSWORD_LOGIN = int(
+        os.getenv("SERVICE_USER_ALLOW_PASSWORD_LOGIN", 1)
+    )
 
     # Open deployment (all dags accessible to all users)
     OPEN_DEPLOYMENT = os.getenv("OPEN_DEPLOYMENT", 1)
@@ -84,14 +93,17 @@ class DefaultConfig(object):
 
 
 class Development(DefaultConfig):
-
-    """ """
+    """
+    Configuration class for development
+    """
 
     ENV = "development"
 
 
 class Testing(DefaultConfig):
-    """ """
+    """
+    Configuration class for testing
+    """
 
     ENV = "testing"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -109,8 +121,18 @@ class Testing(DefaultConfig):
     LOG_LEVEL = int(os.getenv("LOG_LEVEL", 10))
 
 
+class TestingOpenAuth(Testing):
+    """
+    Configuration class for testing some edge cases with Open Auth login
+    """
+
+    AUTH_TYPE = 0
+
+
 class Production(DefaultConfig):
-    """ """
+    """
+    Configuration class for production
+    """
 
     ENV = "production"
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -121,4 +143,9 @@ class Production(DefaultConfig):
     PROPAGATE_EXCEPTIONS = True
 
 
-app_config = {"development": Development, "testing": Testing, "production": Production}
+app_config = {
+    "development": Development,
+    "testing": Testing,
+    "production": Production,
+    "testing-oauth": TestingOpenAuth,
+}

--- a/cornflow-server/cornflow/endpoints/login.py
+++ b/cornflow-server/cornflow/endpoints/login.py
@@ -181,6 +181,9 @@ class LoginBaseEndpoint(BaseMetaResource):
                 )
 
             username = decoded_token["preferred_username"]
+            email = decoded_token.get("email", f"{username}@test.org")
+            first_name = decoded_token.get("given_name", "")
+            last_name = decoded_token.get("family_name", "")
 
             user = self.data_model.get_one_object(username=username)
 
@@ -189,7 +192,12 @@ class LoginBaseEndpoint(BaseMetaResource):
                     f"OpenID user {username} does not exist and is created"
                 )
 
-                data = {"username": username, "email": username}
+                data = {
+                    "username": username,
+                    "email": email,
+                    "first_name": first_name,
+                    "last_name": last_name,
+                }
 
                 user = self.data_model(data=data)
                 user.save()

--- a/cornflow-server/cornflow/endpoints/login.py
+++ b/cornflow-server/cornflow/endpoints/login.py
@@ -38,6 +38,7 @@ class LoginBaseEndpoint(BaseMetaResource):
     def __init__(self):
         super().__init__()
         self.ldap_class = LDAPBase
+        self.user_role_association = UserRoleModel
 
     def log_in(self, **kwargs):
         """
@@ -192,8 +193,6 @@ class LoginBaseEndpoint(BaseMetaResource):
 
                 user = self.data_model(data=data)
                 user.save()
-
-                self.user_role_association(user.id)
 
                 user_role = self.user_role_association(
                     {

--- a/cornflow-server/cornflow/endpoints/login.py
+++ b/cornflow-server/cornflow/endpoints/login.py
@@ -136,58 +136,89 @@ class LoginBaseEndpoint(BaseMetaResource):
 
         return user
 
-    def auth_oid_authenticate(self, token):
+    def auth_oid_authenticate(
+        self, token: str = None, username: str = None, password: str = None
+    ):
         """
-        Method  in charge of performing the log in with the token issued by an Open ID provider
+        Method  in charge of performing the log in with the token issued by an Open ID provider.
+        It has an exception and thus accepts username and password for service users if needed.
 
         :param str token: the token that the user has obtained from the Open ID provider
+        :param str username: the username of the user to log in
+        :param str password: the password of the user to log in
         :return: the user object or it raises an error if it has not been possible to log in
         :rtype: :class:`UserModel`
         """
-        oid_provider = int(current_app.config["OID_PROVIDER"])
 
-        client_id = current_app.config["OID_CLIENT_ID"]
-        tenant_id = current_app.config["OID_TENANT_ID"]
-        issuer = current_app.config["OID_ISSUER"]
+        if token:
 
-        if client_id is None or tenant_id is None or issuer is None:
-            raise ConfigurationError("The OID provider configuration is not valid")
+            oid_provider = int(current_app.config["OID_PROVIDER"])
 
-        if oid_provider == OID_AZURE:
-            decoded_token = self.auth_class().validate_oid_token(
-                token, client_id, tenant_id, issuer, oid_provider
-            )
+            client_id = current_app.config["OID_CLIENT_ID"]
+            tenant_id = current_app.config["OID_TENANT_ID"]
+            issuer = current_app.config["OID_ISSUER"]
 
-        elif oid_provider == OID_GOOGLE:
-            raise EndpointNotImplemented("The selected OID provider is not implemented")
-        elif oid_provider == OID_NONE:
-            raise EndpointNotImplemented("The OID provider configuration is not valid")
+            if client_id is None or tenant_id is None or issuer is None:
+                raise ConfigurationError("The OID provider configuration is not valid")
+
+            if oid_provider == OID_AZURE:
+                decoded_token = self.auth_class().validate_oid_token(
+                    token, client_id, tenant_id, issuer, oid_provider
+                )
+
+            elif oid_provider == OID_GOOGLE:
+                raise EndpointNotImplemented(
+                    "The selected OID provider is not implemented"
+                )
+            elif oid_provider == OID_NONE:
+                raise EndpointNotImplemented(
+                    "The OID provider configuration is not valid"
+                )
+            else:
+                raise EndpointNotImplemented(
+                    "The OID provider configuration is not valid"
+                )
+
+            username = decoded_token["preferred_username"]
+
+            user = self.data_model.get_one_object(username=username)
+
+            if not user:
+                current_app.logger.info(
+                    f"OpenID user {username} does not exist and is created"
+                )
+
+                data = {"username": username, "email": username}
+
+                user = self.data_model(data=data)
+                user.save()
+
+                self.user_role_association(user.id)
+
+                user_role = self.user_role_association(
+                    {
+                        "user_id": user.id,
+                        "role_id": int(current_app.config["DEFAULT_ROLE"]),
+                    }
+                )
+
+                user_role.save()
+
+            return user
+        elif (
+            username
+            and password
+            and current_app.config["SERVICE_USER_ALLOW_PASSWORD_LOGIN"] == 1
+        ):
+
+            user = self.auth_db_authenticate(username, password)
+
+            if user.is_service_user():
+                return user
+            else:
+                raise InvalidUsage("Invalid request")
         else:
-            raise EndpointNotImplemented("The OID provider configuration is not valid")
-
-        username = decoded_token["preferred_username"]
-
-        user = self.data_model.get_one_object(username=username)
-
-        if not user:
-            current_app.logger.info(
-                f"OpenID user {username} does not exist and is created"
-            )
-
-            data = {"username": username, "email": username}
-
-            user = self.data_model(data=data)
-            user.save()
-
-            self.user_role_association(user.id)
-
-            user_role = self.user_role_association(
-                {"user_id": user.id, "role_id": int(current_app.config["DEFAULT_ROLE"])}
-            )
-
-            user_role.save()
-
-        return user
+            raise InvalidUsage("Invalid request")
 
 
 def check_last_password_change(user):

--- a/cornflow-server/cornflow/shared/exceptions.py
+++ b/cornflow-server/cornflow/shared/exceptions.py
@@ -2,6 +2,7 @@
 This file contains the different exceptions created to report errors and the handler that registers them
 on a flask REST API server
 """
+
 from flask import jsonify
 from webargs.flaskparser import parser
 from cornflow_client.constants import AirflowError
@@ -123,9 +124,11 @@ class ConfigurationError(InvalidUsage):
 
 
 INTERNAL_SERVER_ERROR_MESSAGE = "500 Internal Server Error"
-INTERNAL_SERVER_ERROR_MESSAGE_DETAIL = "The server encountered an internal error and was unable " \
-                                       "to complete your request. Either the server is overloaded or " \
-                                       "there is an error in the application."
+INTERNAL_SERVER_ERROR_MESSAGE_DETAIL = (
+    "The server encountered an internal error and was unable "
+    "to complete your request. Either the server is overloaded or "
+    "there is an error in the application."
+)
 
 
 def initialize_errorhandlers(app):
@@ -146,6 +149,7 @@ def initialize_errorhandlers(app):
     @app.errorhandler(InvalidData)
     @app.errorhandler(InvalidPatch)
     @app.errorhandler(ConfigurationError)
+    @app.errorhandler(CommunicationError)
     def handle_invalid_usage(error):
         """
         Method to handle the error given by the different exceptions.
@@ -187,10 +191,7 @@ def initialize_errorhandlers(app):
             status_code = error.code or status_code
             error_msg = f"{status_code} {error.name or INTERNAL_SERVER_ERROR_MESSAGE}"
             error_str = f"{error_msg}. {str(error.description or '') or INTERNAL_SERVER_ERROR_MESSAGE_DETAIL}"
-            response_dict = {
-                "message": error_msg,
-                "error": error_str
-            }
+            response_dict = {"message": error_msg, "error": error_str}
             response = jsonify(response_dict)
 
         elif app.config["ENV"] == "production":
@@ -202,7 +203,7 @@ def initialize_errorhandlers(app):
 
             response_dict = {
                 "message": INTERNAL_SERVER_ERROR_MESSAGE,
-                "error": INTERNAL_SERVER_ERROR_MESSAGE_DETAIL
+                "error": INTERNAL_SERVER_ERROR_MESSAGE_DETAIL,
             }
             response = jsonify(response_dict)
         else:

--- a/cornflow-server/cornflow/tests/unit/test_log_in.py
+++ b/cornflow-server/cornflow/tests/unit/test_log_in.py
@@ -43,6 +43,24 @@ class TestLogIn(LoginTestCases.LoginEndpoint):
         super().test_successful_log_in()
         self.assertEqual(self.idx, self.response.json["id"])
 
+    @mock.patch("cornflow.endpoints.login.LoginBaseEndpoint.auth_class")
+    def test_exception_on_token_generation(self, mock_token):
+        mock_token.generate_token.side_effect = Exception("Custom exception")
+
+        payload = self.data
+
+        response = self.client.post(
+            LOGIN_URL,
+            data=json.dumps(payload),
+            follow_redirects=True,
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(400, response.status_code)
+        self.assertIn("Error in generating user token", response.json["error"])
+
+        pass
+
 
 class TestLogInOpenAuthNoConfig(CustomTestCase):
     def create_app(self):

--- a/cornflow-server/cornflow/tests/unit/test_log_in.py
+++ b/cornflow-server/cornflow/tests/unit/test_log_in.py
@@ -212,12 +212,36 @@ class TestLogInOpenAuthAzure(CustomTestCase):
             headers={"Content-Type": "application/json"},
         )
 
-        print(response.json)
-
         self.assertEqual(400, response.status_code)
         self.assertIn(
             "Error getting issuer discovery meta from", response.json["error"]
         )
+
+    @mock.patch("cornflow.endpoints.login.Auth.validate_oid_token")
+    def test_service_user_login_no_fail(self, mock_auth):
+        mock_auth.return_value = {"preferred_username": "service_user"}
+        response = self.client.post(
+            LOGIN_URL,
+            data=json.dumps({"token": "some_token"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+        print(response.json)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(self.service_user_id, response.json["id"])
+
+    @mock.patch("cornflow.endpoints.login.Auth.validate_oid_token")
+    def test_new_user_login_no_fail(self, mock_auth):
+        mock_auth.return_value = {"preferred_username": "test_user"}
+        response = self.client.post(
+            LOGIN_URL,
+            data=json.dumps({"token": "some_token"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(self.service_user_id + 1, response.json["id"])
 
 
 class TestLogInOpenAuthGoogle(CustomTestCase):

--- a/cornflow-server/cornflow/tests/unit/test_log_in.py
+++ b/cornflow-server/cornflow/tests/unit/test_log_in.py
@@ -4,7 +4,7 @@ Unit test for the log in endpoint
 
 import json
 import logging as log
-
+from unittest import mock
 
 from flask import current_app
 
@@ -14,7 +14,7 @@ from cornflow.commands.access import access_init_command
 from cornflow.commands.dag import register_deployed_dags_command_test
 from cornflow.models import UserModel
 from cornflow.shared import db
-from cornflow.shared.const import SERVICE_ROLE
+from cornflow.shared.const import SERVICE_ROLE, OID_GOOGLE, OID_AZURE
 from cornflow.tests.const import LOGIN_URL
 from cornflow.tests.custom_test_case import CustomTestCase, LoginTestCases
 
@@ -44,7 +44,7 @@ class TestLogIn(LoginTestCases.LoginEndpoint):
         self.assertEqual(self.idx, self.response.json["id"])
 
 
-class TestLogInOpenAuth(CustomTestCase):
+class TestLogInOpenAuthNoConfig(CustomTestCase):
     def create_app(self):
         """
         Creates and configures a Flask application for testing.
@@ -113,6 +113,142 @@ class TestLogInOpenAuth(CustomTestCase):
 
         self.assertEqual(400, response.status_code)
         self.assertEqual(response.json["error"], "Invalid request")
+
+
+class TestLogInOpenAuthAzure(CustomTestCase):
+    def create_app(self):
+        """
+        Creates and configures a Flask application for testing.
+
+        :returns: A configured Flask application instance
+        :rtype: Flask
+        """
+        app = create_app("testing-oauth")
+        app.config["SERVICE_USER_ALLOW_PASSWORD_LOGIN"] = 0
+        app.config["OID_PROVIDER"] = OID_AZURE
+        app.config["OID_CLIENT_ID"] = "SOME_SECRET"
+        app.config["OID_TENANT_ID"] = "SOME_SECRET"
+        app.config["OID_ISSUER"] = "SOME_SECRET"
+        return app
+
+    def setUp(self):
+        log.root.setLevel(current_app.config["LOG_LEVEL"])
+        db.create_all()
+        access_init_command(verbose=False)
+        register_deployed_dags_command_test(verbose=False)
+
+        self.service_data = {
+            "username": "service_user",
+            "email": "service@test.com",
+            "password": "Testpassword1!",
+        }
+
+        service_user = UserModel(data=self.service_data)
+        service_user.save()
+
+        self.service_data.pop("email")
+        self.service_user_id = service_user.id
+
+        self.assign_role(self.service_user_id, SERVICE_ROLE)
+
+    def test_service_user_login_first_fail(self):
+        """
+        Tests that a service user can not log in with username and password
+        """
+        response = self.client.post(
+            LOGIN_URL,
+            data=json.dumps({"token": "some_token"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(response.json["error"], "Token is not valid")
+
+    @mock.patch("cornflow.shared.authentication.auth.jwt")
+    def test_service_user_login_second_fail(self, mock_header):
+        """
+        Tests second exit point on token validation
+        """
+        mock_header.get_unverified_header.return_value = None
+        response = self.client.post(
+            LOGIN_URL,
+            data=json.dumps({"token": "some_token"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(response.json["error"], "Token is missing the headers")
+
+    @mock.patch("cornflow.shared.authentication.auth.jwt")
+    def test_service_user_login_third_fail(self, mock_header):
+        """
+        Tests third exit point on token validation
+        """
+        mock_header.get_unverified_header.return_value = {"kid": "some_value"}
+        response = self.client.post(
+            LOGIN_URL,
+            data=json.dumps({"token": "some_token"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+        print(response.json)
+
+        self.assertEqual(400, response.status_code)
+        self.assertIn(
+            "Error getting issuer discovery meta from", response.json["error"]
+        )
+
+
+class TestLogInOpenAuthGoogle(CustomTestCase):
+    def create_app(self):
+        """
+        Creates and configures a Flask application for testing.
+
+        :returns: A configured Flask application instance
+        :rtype: Flask
+        """
+        app = create_app("testing-oauth")
+        app.config["SERVICE_USER_ALLOW_PASSWORD_LOGIN"] = 0
+        app.config["OID_PROVIDER"] = OID_GOOGLE
+        app.config["OID_CLIENT_ID"] = "SOME_SECRET"
+        app.config["OID_TENANT_ID"] = "SOME_SECRET"
+        app.config["OID_ISSUER"] = "SOME_SECRET"
+        return app
+
+    def setUp(self):
+        log.root.setLevel(current_app.config["LOG_LEVEL"])
+        db.create_all()
+        access_init_command(verbose=False)
+        register_deployed_dags_command_test(verbose=False)
+
+        self.service_data = {
+            "username": "service_user",
+            "email": "service@test.com",
+            "password": "Testpassword1!",
+        }
+
+        service_user = UserModel(data=self.service_data)
+        service_user.save()
+
+        self.service_data.pop("email")
+        self.service_user_id = service_user.id
+
+        self.assign_role(self.service_user_id, SERVICE_ROLE)
+
+    def test_service_user_login(self):
+        """
+        Tests that a service user can not log in with username and password
+        """
+        response = self.client.post(
+            LOGIN_URL,
+            data=json.dumps({"token": "some_token"}),
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(501, response.status_code)
+        self.assertEqual(
+            response.json["error"], "The selected OID provider is not implemented"
+        )
 
 
 class TestLogInOpenAuthService(CustomTestCase):

--- a/cornflow-server/cornflow/tests/unit/test_log_in.py
+++ b/cornflow-server/cornflow/tests/unit/test_log_in.py
@@ -43,12 +43,15 @@ class TestLogIn(LoginTestCases.LoginEndpoint):
         super().test_successful_log_in()
         self.assertEqual(self.idx, self.response.json["id"])
 
-    @mock.patch("cornflow.endpoints.login.LoginBaseEndpoint.auth_class")
-    def test_exception_on_token_generation(self, mock_token):
-        mock_token.generate_token.side_effect = Exception("Custom exception")
+    @mock.patch("cornflow.endpoints.login.Auth.generate_token")
+    def test_exception_on_token_generation(self, mock_generate_token):
+        # Simulate an exception when generate_token is called
+        mock_generate_token.side_effect = Exception("Custom exception")
 
+        # Prepare login payload
         payload = self.data
 
+        # Make a login request
         response = self.client.post(
             LOGIN_URL,
             data=json.dumps(payload),
@@ -56,10 +59,10 @@ class TestLogIn(LoginTestCases.LoginEndpoint):
             headers={"Content-Type": "application/json"},
         )
 
+        # Assert that the response is a 400 error
         self.assertEqual(400, response.status_code)
+        # Assert that the error message contains the expected text
         self.assertIn("Error in generating user token", response.json["error"])
-
-        pass
 
 
 class TestLogInOpenAuthNoConfig(CustomTestCase):
@@ -369,7 +372,7 @@ class TestLogInOpenAuthOther(CustomTestCase):
 
         self.assertEqual(501, response.status_code)
         self.assertEqual(
-            response.json["error"], "The selected OID provider is not implemented"
+            response.json["error"], "The OID provider configuration is not valid"
         )
 
 


### PR DESCRIPTION
- Added support for username and password login for service users in the OpenID authentication process, controlled by the new configuration option `SERVICE_USER_ALLOW_PASSWORD_LOGIN`.
- Introduced a new configuration class `TestingOpenAuth` for testing scenarios involving OpenID authentication.
- Updated the `LoginOpenAuthRequest` schema to validate that either a token is provided or both username and password are present, ensuring proper authentication flow.
- Enhanced the `LoginBaseEndpoint` to handle various authentication scenarios, including error handling for invalid requests.
- Improved documentation across configuration classes and schemas for better clarity and maintainability.