### PR TITLE
Implement application root configuration and middleware support

### DIFF
--- a/cornflow-server/cornflow/app.py
+++ b/cornflow-server/cornflow/app.py
@@ -1,6 +1,7 @@
 """
 Main file with the creation of the app logic
 """
+
 # Full imports
 import os
 import click
@@ -13,6 +14,8 @@ from flask_cors import CORS
 from flask_migrate import Migrate
 from flask_restful import Api
 from logging.config import dictConfig
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from werkzeug.exceptions import NotFound
 
 # Module imports
 from cornflow.commands import (
@@ -111,6 +114,11 @@ def create_app(env_name="development", dataconn=None):
     app.cli.add_command(access_init)
     app.cli.add_command(register_deployed_dags)
     app.cli.add_command(register_dag_permissions)
+
+    if app.config["APPLICATION_ROOT"] != "/" and app.config["EXTERNAL_APP"] == 0:
+        app.wsgi_app = DispatcherMiddleware(
+            NotFound(), {app.config["APPLICATION_ROOT"]: app.wsgi_app}
+        )
 
     return app
 

--- a/cornflow-server/cornflow/config.py
+++ b/cornflow-server/cornflow/config.py
@@ -5,6 +5,8 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 
 
 class DefaultConfig(object):
+    APPLICATION_ROOT = os.getenv("APPLICATION_ROOT", "/")
+    EXTERNAL_APP = int(os.getenv("EXTERNAL_APP", 0))
     SERVICE_NAME = os.getenv("SERVICE_NAME", "Cornflow")
     SECRET_TOKEN_KEY = os.getenv("SECRET_KEY")
     SECRET_BI_KEY = os.getenv("SECRET_BI_KEY")
@@ -84,7 +86,6 @@ class DefaultConfig(object):
 
 
 class Development(DefaultConfig):
-
     """ """
 
     ENV = "development"
@@ -109,6 +110,14 @@ class Testing(DefaultConfig):
     LOG_LEVEL = int(os.getenv("LOG_LEVEL", 10))
 
 
+class TestingApplicationRoot(Testing):
+    """
+    Configuration class for testing with application root
+    """
+
+    APPLICATION_ROOT = "/test"
+
+
 class Production(DefaultConfig):
     """ """
 
@@ -121,4 +130,9 @@ class Production(DefaultConfig):
     PROPAGATE_EXCEPTIONS = True
 
 
-app_config = {"development": Development, "testing": Testing, "production": Production}
+app_config = {
+    "development": Development,
+    "testing": Testing,
+    "testing-root": TestingApplicationRoot,
+    "production": Production,
+}

--- a/cornflow-server/cornflow/tests/unit/test_application.py
+++ b/cornflow-server/cornflow/tests/unit/test_application.py
@@ -1,0 +1,60 @@
+"""
+File to test different application configurations
+"""
+
+import json
+import logging as log
+
+from flask import current_app
+
+from cornflow.app import create_app
+from cornflow.models import UserModel
+from cornflow.commands.access import access_init_command
+from cornflow.commands.dag import register_deployed_dags_command_test
+from cornflow.shared import db
+from cornflow.tests.const import LOGIN_URL
+from cornflow.tests.custom_test_case import CustomTestCase
+
+
+class TestApplicationRoot(CustomTestCase):
+
+    def create_app(self):
+        return create_app("testing-root")
+
+    def setUp(self):
+        log.root.setLevel(current_app.config["LOG_LEVEL"])
+        db.create_all()
+        access_init_command(verbose=False)
+        register_deployed_dags_command_test(verbose=False)
+        self.data = {
+            "username": "testname",
+            "email": "test@test.com",
+            "password": "Testpassword1!",
+        }
+
+        user = UserModel(self.data)
+        user.save()
+
+        self.data.pop("email")
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+
+    def test_wrong_route(self):
+        response = self.client.post(
+            LOGIN_URL,
+            data=json.dumps(self.data),
+            follow_redirects=True,
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_correct_route(self):
+        response = self.client.post(
+            f"{current_app.config['APPLICATION_ROOT']}{LOGIN_URL}",
+            data=json.dumps(self.data),
+            follow_redirects=True,
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
- Added APPLICATION_ROOT and EXTERNAL_APP configuration options to DefaultConfig for better application routing.
- Introduced DispatcherMiddleware in app.py to handle requests based on APPLICATION_ROOT, improving flexibility for deployment scenarios.
- Created TestingApplicationRoot class for testing environments with a specific application root.

These changes enhance the application's configurability and middleware handling, facilitating better integration in various environments.

Closes #589