### PR TITLE
Feature/dockerfiles

### DIFF
--- a/cornflow-server/Dockerfile
+++ b/cornflow-server/Dockerfile
@@ -5,8 +5,8 @@ FROM python:3.12-slim
 LABEL maintainer="cornflow@baobabsoluciones"
 
 # Never prompt the user for choices on installation/configuration of packages
-ENV DEBIAN_FRONTEND noninteractive
-ENV TERM linux
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=linux
 
 # CORNFLOW vars
 ARG CORNFLOW_VERSION=1.2.4
@@ -25,8 +25,8 @@ RUN apt update -y && apt-get install -y --no-install-recommends \
 WORKDIR /usr/src/app
 
 # set environment variables
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 ENV DEFAULT_POSTGRES=1
 
 # install dependencies

--- a/cornflow-server/airflow_config/Dockerfile
+++ b/cornflow-server/airflow_config/Dockerfile
@@ -7,8 +7,8 @@ FROM baobabsoluciones/pysolver:1.1
 LABEL maintainer="cornflow@baobabsoluciones"
 
 # Never prompt the user for choices on installation/configuration of packages
-ENV DEBIAN_FRONTEND noninteractive
-ENV TERM linux
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=linux
 
 # Airflow vars
 ARG AIRFLOW_VERSION=2.9.1

--- a/cornflow-server/airflow_config/Dockerfile.base
+++ b/cornflow-server/airflow_config/Dockerfile.base
@@ -5,8 +5,8 @@ FROM python:3.12-slim
 LABEL maintainer="cornflow@baobabsoluciones"
 
 # Never prompt the user for choices on installation/configuration of packages
-ENV DEBIAN_FRONTEND noninteractive
-ENV TERM linux
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=linux
 
 # solver vars
 ENV SOLVER_DIR=/usr/local/solvers


### PR DESCRIPTION
Fixed the following warning on the cornflow Dockerfile:

```
4 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 8)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 9)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 28)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 29)
```