### PR TITLE
Table endpoints are optional

### DIFF
--- a/cornflow-server/cornflow/app.py
+++ b/cornflow-server/cornflow/app.py
@@ -122,7 +122,7 @@ def create_app(env_name="development", dataconn=None):
         )
     elif auth_type == AUTH_OID:
         api.add_resource(
-            LoginOpenAuthEndpoint, CONDITIONAL_ENDPOINTS["login"], endpoint="login"
+            LoginOpenAuthEndpoint, CONDITIONAL_ENDPOINTS_URLS["login"], endpoint="login"
         )
     else:
         raise ConfigurationError(

--- a/cornflow-server/cornflow/app.py
+++ b/cornflow-server/cornflow/app.py
@@ -32,7 +32,7 @@ from cornflow.commands import (
     register_dag_permissions_command,
 )
 from cornflow.config import app_config
-from cornflow.endpoints import resources, alarms_resources, table_resources
+from cornflow.endpoints import resources, alarms_resources, tables_resources
 from cornflow.endpoints.login import LoginEndpoint, LoginOpenAuthEndpoint
 from cornflow.endpoints.signup import SignUpEndpoint
 from cornflow.shared import db, bcrypt
@@ -91,7 +91,7 @@ def create_app(env_name="development", dataconn=None):
         for res in alarms_resources:
             api.add_resource(res["resource"], res["urls"], endpoint=res["endpoint"])
     if app.config["TABLES_ENDPOINTS"]:
-        for res in table_resources:
+        for res in tables_resources:
             api.add_resource(res["resource"], res["urls"], endpoint=res["endpoint"])
 
     docs = FlaskApiSpec(app)
@@ -101,7 +101,7 @@ def create_app(env_name="development", dataconn=None):
         for res in alarms_resources:
             docs.register(target=res["resource"], endpoint=res["endpoint"])
     if app.config["TABLES_ENDPOINTS"]:
-        for res in table_resources:
+        for res in tables_resources:
             docs.register(target=res["resource"], endpoint=res["endpoint"])
 
     # Resource for the log-in

--- a/cornflow-server/cornflow/app.py
+++ b/cornflow-server/cornflow/app.py
@@ -32,7 +32,7 @@ from cornflow.commands import (
     register_dag_permissions_command,
 )
 from cornflow.config import app_config
-from cornflow.endpoints import resources, alarms_resources
+from cornflow.endpoints import resources, alarms_resources, table_resources
 from cornflow.endpoints.login import LoginEndpoint, LoginOpenAuthEndpoint
 from cornflow.endpoints.signup import SignUpEndpoint
 from cornflow.shared import db, bcrypt
@@ -90,12 +90,18 @@ def create_app(env_name="development", dataconn=None):
     if app.config["ALARMS_ENDPOINTS"]:
         for res in alarms_resources:
             api.add_resource(res["resource"], res["urls"], endpoint=res["endpoint"])
+    if app.config["TABLES_ENDPOINTS"]:
+        for res in table_resources:
+            api.add_resource(res["resource"], res["urls"], endpoint=res["endpoint"])
 
     docs = FlaskApiSpec(app)
     for res in resources:
         docs.register(target=res["resource"], endpoint=res["endpoint"])
     if app.config["ALARMS_ENDPOINTS"]:
         for res in alarms_resources:
+            docs.register(target=res["resource"], endpoint=res["endpoint"])
+    if app.config["TABLES_ENDPOINTS"]:
+        for res in table_resources:
             docs.register(target=res["resource"], endpoint=res["endpoint"])
 
     # Resource for the log-in

--- a/cornflow-server/cornflow/app.py
+++ b/cornflow-server/cornflow/app.py
@@ -41,7 +41,7 @@ from cornflow.shared.const import (
     AUTH_DB,
     AUTH_LDAP,
     AUTH_OID,
-    CONDITIONAL_ENDPOINTS,
+    CONDITIONAL_ENDPOINTS_URLS,
     SIGNUP_WITH_AUTH,
     SIGNUP_WITH_NO_AUTH,
 )
@@ -111,14 +111,14 @@ def create_app(env_name="development", dataconn=None):
         signup_activated = int(app.config["SIGNUP_ACTIVATED"])
         if signup_activated in [SIGNUP_WITH_AUTH, SIGNUP_WITH_NO_AUTH]:
             api.add_resource(
-                SignUpEndpoint, CONDITIONAL_ENDPOINTS["signup"], endpoint="signup"
+                SignUpEndpoint, CONDITIONAL_ENDPOINTS_URLS["signup"], endpoint="signup"
             )
         api.add_resource(
-            LoginEndpoint, CONDITIONAL_ENDPOINTS["login"], endpoint="login"
+            LoginEndpoint, CONDITIONAL_ENDPOINTS_URLS["login"], endpoint="login"
         )
     elif auth_type == AUTH_LDAP:
         api.add_resource(
-            LoginEndpoint, CONDITIONAL_ENDPOINTS["login"], endpoint="login"
+            LoginEndpoint, CONDITIONAL_ENDPOINTS_URLS["login"], endpoint="login"
         )
     elif auth_type == AUTH_OID:
         api.add_resource(

--- a/cornflow-server/cornflow/commands/auxiliar.py
+++ b/cornflow-server/cornflow/commands/auxiliar.py
@@ -3,7 +3,7 @@ from importlib import import_module
 
 from flask import current_app
 
-from cornflow.endpoints import alarms_resources, get_resources
+from cornflow.endpoints import alarms_resources, get_resources, tables_resources
 from cornflow.models import RoleModel
 from cornflow.shared.const import (
     EXTRA_PERMISSION_ASSIGNATION,
@@ -25,7 +25,9 @@ def get_all_external(external_app):
         extra_permissions = EXTRA_PERMISSION_ASSIGNATION
         custom_roles_actions = {}
         if current_app.config["ALARMS_ENDPOINTS"]:
-            resources_to_register = resources + alarms_resources
+            resources_to_register += alarms_resources
+        if current_app.config["TABLES_ENDPOINTS"]:
+            resources_to_register += tables_resources
     else:
         sys.path.append("./")
         external_module = import_module(external_app)
@@ -42,12 +44,11 @@ def get_all_external(external_app):
         except AttributeError:
             custom_roles_actions = {}
 
+        resources_to_register = external_module.endpoints.resources + resources
         if current_app.config["ALARMS_ENDPOINTS"]:
-            resources_to_register = (
-                external_module.endpoints.resources + resources + alarms_resources
-            )
-        else:
-            resources_to_register = external_module.endpoints.resources + resources
+            resources_to_register += alarms_resources
+        if current_app.config["TABLES_ENDPOINTS"]:
+            resources_to_register += tables_resources
     return resources_to_register, extra_permissions, custom_roles_actions
 
 

--- a/cornflow-server/cornflow/commands/views.py
+++ b/cornflow-server/cornflow/commands/views.py
@@ -188,16 +188,21 @@ def get_resources_to_register(external_app):
     if external_app is None:
         resources_to_register = resources
         if current_app.config["ALARMS_ENDPOINTS"]:
-            resources_to_register = resources + alarms_resources
+            resources_to_register += alarms_resources
             current_app.logger.info(" ALARMS ENDPOINTS ENABLED ")
+        if current_app.config["TABLES_ENDPOINTS"]:
+            resources_to_register += tables_resources
+            current_app.logger.info(" TABLES ENDPOINTS ENABLED ")
     else:
         current_app.logger.info(f" USING EXTERNAL APP: {external_app} ")
         sys.path.append("./")
         external_module = import_module(external_app)
+        resources_to_register = external_module.endpoints.resources + resources
         if current_app.config["ALARMS_ENDPOINTS"]:
-            resources_to_register = (
-                external_module.endpoints.resources + resources + alarms_resources
-            )
-        else:
-            resources_to_register = external_module.endpoints.resources + resources
+            resources_to_register += alarms_resources
+            current_app.logger.info(" ALARMS ENDPOINTS ENABLED ")
+        if current_app.config["TABLES_ENDPOINTS"]:
+            resources_to_register += tables_resources
+            current_app.logger.info(" TABLES ENDPOINTS ENABLED ")
+
     return resources_to_register

--- a/cornflow-server/cornflow/commands/views.py
+++ b/cornflow-server/cornflow/commands/views.py
@@ -8,7 +8,7 @@ from sqlalchemy.exc import DBAPIError, IntegrityError
 from cornflow.endpoints import (
     resources,
     alarms_resources,
-    table_resources,
+    tables_resources,
     get_resources,
 )
 
@@ -194,7 +194,7 @@ def get_resources_to_register(external_app):
             resources_to_register += alarms_resources
             current_app.logger.info(" ALARMS ENDPOINTS ENABLED ")
         if current_app.config["TABLES_ENDPOINTS"]:
-            resources_to_register += table_resources
+            resources_to_register += tables_resources
             current_app.logger.info(" TABLES ENDPOINTS ENABLED ")
     else:
         current_app.logger.info(f" USING EXTERNAL APP: {external_app} ")
@@ -205,7 +205,7 @@ def get_resources_to_register(external_app):
             resources_to_register += alarms_resources
             current_app.logger.info(" ALARMS ENDPOINTS ENABLED ")
         if current_app.config["TABLES_ENDPOINTS"]:
-            resources_to_register += table_resources
+            resources_to_register += tables_resources
             current_app.logger.info(" TABLES ENDPOINTS ENABLED ")
 
     return resources_to_register

--- a/cornflow-server/cornflow/commands/views.py
+++ b/cornflow-server/cornflow/commands/views.py
@@ -5,9 +5,12 @@ from importlib import import_module
 from flask import current_app
 from sqlalchemy.exc import DBAPIError, IntegrityError
 
-from cornflow.endpoints import resources, alarms_resources
-
-from cornflow.endpoints import alarms_resources, get_resources
+from cornflow.endpoints import (
+    resources,
+    alarms_resources,
+    table_resources,
+    get_resources,
+)
 
 # Imports from internal libraries
 from cornflow.models import ViewModel
@@ -191,7 +194,7 @@ def get_resources_to_register(external_app):
             resources_to_register += alarms_resources
             current_app.logger.info(" ALARMS ENDPOINTS ENABLED ")
         if current_app.config["TABLES_ENDPOINTS"]:
-            resources_to_register += tables_resources
+            resources_to_register += table_resources
             current_app.logger.info(" TABLES ENDPOINTS ENABLED ")
     else:
         current_app.logger.info(f" USING EXTERNAL APP: {external_app} ")
@@ -202,7 +205,7 @@ def get_resources_to_register(external_app):
             resources_to_register += alarms_resources
             current_app.logger.info(" ALARMS ENDPOINTS ENABLED ")
         if current_app.config["TABLES_ENDPOINTS"]:
-            resources_to_register += tables_resources
+            resources_to_register += table_resources
             current_app.logger.info(" TABLES ENDPOINTS ENABLED ")
 
     return resources_to_register

--- a/cornflow-server/cornflow/config.py
+++ b/cornflow-server/cornflow/config.py
@@ -1,5 +1,11 @@
 import os
-from .shared.const import AUTH_DB, PLANNER_ROLE, AUTH_OID, SIGNUP_WITH_AUTH, SIGNUP_WITH_NO_AUTH
+from .shared.const import (
+    AUTH_DB,
+    PLANNER_ROLE,
+    AUTH_OID,
+    SIGNUP_WITH_AUTH,
+    SIGNUP_WITH_NO_AUTH,
+)
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 
@@ -83,7 +89,10 @@ class DefaultConfig(object):
     SERVICE_EMAIL_PORT = os.getenv("SERVICE_EMAIL_PORT", None)
 
     # Alarms endpoints
-    ALARMS_ENDPOINTS = os.getenv("CF_ALARMS_ENDPOINT", 0)
+    ALARMS_ENDPOINTS = int(os.getenv("CF_ALARMS_ENDPOINT", 0))
+
+    # Tables endpoints
+    TABLES_ENDPOINTS = int(os.getenv("CF_TABLES_ENDPOINT", 0))
 
     # Token duration in hours
     TOKEN_DURATION = os.getenv("TOKEN_DURATION", 24)
@@ -121,10 +130,12 @@ class Testing(DefaultConfig):
     LOG_LEVEL = int(os.getenv("LOG_LEVEL", 10))
     SIGNUP_ACTIVATED = SIGNUP_WITH_NO_AUTH
 
+
 class TestingOpenAuth(Testing):
     """
     Configuration class for testing some edge cases with Open Auth login
     """
+
     AUTH_TYPE = AUTH_OID
     OID_PROVIDER = "https://test-provider.example.com"
     OID_EXPECTED_AUDIENCE = "test-audience-id"

--- a/cornflow-server/cornflow/config.py
+++ b/cornflow-server/cornflow/config.py
@@ -149,6 +149,14 @@ class TestingApplicationRoot(Testing):
     APPLICATION_ROOT = "/test"
 
 
+class TestingTableEndpoints(Testing):
+    """
+    Configuration class for testing with table endpoints
+    """
+
+    TABLES_ENDPOINTS = 1
+
+
 class Production(DefaultConfig):
     """
     Configuration class for production
@@ -169,4 +177,5 @@ app_config = {
     "production": Production,
     "testing-oauth": TestingOpenAuth,
     "testing-root": TestingApplicationRoot,
+    "testing-table-endpoints": TestingTableEndpoints,
 }

--- a/cornflow-server/cornflow/endpoints/__init__.py
+++ b/cornflow-server/cornflow/endpoints/__init__.py
@@ -5,7 +5,10 @@ The login resource gets created on app startup as it depends on configuration
 """
 
 from flask import current_app
-from cornflow.shared.const import CONDITIONAL_ENDPOINTS
+from cornflow.shared.const import (
+    CONDITIONAL_ENDPOINTS_BASE_CLASS,
+    CONDITIONAL_ENDPOINTS_URLS,
+)
 from .action import ActionListEndpoint
 from .alarms import AlarmsEndpoint, AlarmDetailEndpoint
 from .apiview import ApiViewListEndpoint
@@ -254,14 +257,14 @@ def get_resources():
     """
     base_resources = resources.copy()
 
-    for resource in CONDITIONAL_ENDPOINTS.keys():
+    for resource in CONDITIONAL_ENDPOINTS_URLS.keys():
         if resource not in [
             present_resource["endpoint"] for present_resource in base_resources
         ]:
             base_resources.append(
                 dict(
-                    resource=current_app.view_functions[resource].view_class,
-                    urls=CONDITIONAL_ENDPOINTS[resource],
+                    resource=CONDITIONAL_ENDPOINTS_BASE_CLASS[resource],
+                    urls=CONDITIONAL_ENDPOINTS_URLS[resource],
                     endpoint=resource,
                 )
             )

--- a/cornflow-server/cornflow/endpoints/__init__.py
+++ b/cornflow-server/cornflow/endpoints/__init__.py
@@ -6,7 +6,6 @@ The login resource gets created on app startup as it depends on configuration
 
 from flask import current_app
 from cornflow.shared.const import (
-    CONDITIONAL_ENDPOINTS_BASE_CLASS,
     CONDITIONAL_ENDPOINTS_URLS,
 )
 from .action import ActionListEndpoint
@@ -59,6 +58,9 @@ from .tables import TablesEndpoint, TablesDetailsEndpoint
 from .token import TokenEndpoint
 from .user import UserEndpoint, UserDetailsEndpoint, ToggleUserAdmin, RecoverPassword
 from .user_role import UserRoleListEndpoint, UserRoleDetailEndpoint
+
+from .signup import SignUpEndpoint
+from .login import LoginEndpoint
 
 resources = [
     dict(resource=InstanceEndpoint, urls="/instance/", endpoint="instance"),
@@ -256,6 +258,11 @@ def get_resources():
     :rtype: list
     """
     base_resources = resources.copy()
+
+    CONDITIONAL_ENDPOINTS_BASE_CLASS = {
+        "signup": SignUpEndpoint,
+        "login": LoginEndpoint,
+    }
 
     for resource in CONDITIONAL_ENDPOINTS_URLS.keys():
         if resource not in [

--- a/cornflow-server/cornflow/endpoints/__init__.py
+++ b/cornflow-server/cornflow/endpoints/__init__.py
@@ -246,24 +246,23 @@ tables_resources = [
 
 def get_resources():
     """
-    Get the resources based on the configuration
+    Get the base resources in cornflow plñus the login and signup resources to generate
+    the permissions associated with them
 
     :return: The resources based on the configuration
     :rtype: list
     """
     base_resources = resources.copy()
-    registered_resources = current_app.view_functions.keys()
-    for resource in registered_resources:
-        if resource in CONDITIONAL_ENDPOINTS.keys():
-            # Check if the resource already exists
-            if resource not in [
-                present_resource["endpoint"] for present_resource in base_resources
-            ]:
-                base_resources.append(
-                    dict(
-                        resource=current_app.view_functions[resource].view_class,
-                        urls=CONDITIONAL_ENDPOINTS[resource],
-                        endpoint=resource,
-                    )
+
+    for resource in CONDITIONAL_ENDPOINTS.keys():
+        if resource not in [
+            present_resource["endpoint"] for present_resource in base_resources
+        ]:
+            base_resources.append(
+                dict(
+                    resource=current_app.view_functions[resource].view_class,
+                    urls=CONDITIONAL_ENDPOINTS[resource],
+                    endpoint=resource,
                 )
+            )
     return base_resources

--- a/cornflow-server/cornflow/endpoints/__init__.py
+++ b/cornflow-server/cornflow/endpoints/__init__.py
@@ -232,7 +232,7 @@ alarms_resources = [
     ),
 ]
 
-table_resources = [
+tables_resources = [
     dict(
         resource=TablesEndpoint, urls="/table/<string:table_name>/", endpoint="tables"
     ),

--- a/cornflow-server/cornflow/endpoints/__init__.py
+++ b/cornflow-server/cornflow/endpoints/__init__.py
@@ -211,14 +211,6 @@ resources = [
         urls="/licences/",
         endpoint="licences",
     ),
-    dict(
-        resource=TablesEndpoint, urls="/table/<string:table_name>/", endpoint="tables"
-    ),
-    dict(
-        resource=TablesDetailsEndpoint,
-        urls="/table/<string:table_name>/<string:idx>/",
-        endpoint="tables-detail",
-    ),
 ]
 
 
@@ -237,6 +229,17 @@ alarms_resources = [
         resource=MainAlarmsEndpoint,
         urls="/main-alarms/",
         endpoint="main-alarms",
+    ),
+]
+
+table_resources = [
+    dict(
+        resource=TablesEndpoint, urls="/table/<string:table_name>/", endpoint="tables"
+    ),
+    dict(
+        resource=TablesDetailsEndpoint,
+        urls="/table/<string:table_name>/<string:idx>/",
+        endpoint="tables-detail",
     ),
 ]
 

--- a/cornflow-server/cornflow/shared/const.py
+++ b/cornflow-server/cornflow/shared/const.py
@@ -2,9 +2,6 @@
 In this file we import the values for different constants on cornflow server
 """
 
-from cornflow.endpoints.signup import SignUpEndpoint
-from cornflow.endpoints.login import LoginEndpoint
-
 CORNFLOW_VERSION = "1.2.4"
 INTERNAL_TOKEN_ISSUER = "cornflow"
 
@@ -131,11 +128,6 @@ AIRFLOW_ERROR_MSG = "Airflow responded with an error:"
 DATA_DOES_NOT_EXIST_MSG = "The data entity does not exist on the database"
 
 # Conditional endpoints
-CONDITIONAL_ENDPOINTS_BASE_CLASS = {
-    "signup": SignUpEndpoint,
-    "login": LoginEndpoint,
-}
-
 CONDITIONAL_ENDPOINTS_URLS = {
     "signup": "/signup/",
     "login": "/login/",

--- a/cornflow-server/cornflow/shared/const.py
+++ b/cornflow-server/cornflow/shared/const.py
@@ -2,6 +2,9 @@
 In this file we import the values for different constants on cornflow server
 """
 
+from cornflow.endpoints.signup import SignUpEndpoint
+from cornflow.endpoints.login import LoginEndpoint
+
 CORNFLOW_VERSION = "1.2.4"
 INTERNAL_TOKEN_ISSUER = "cornflow"
 
@@ -128,7 +131,12 @@ AIRFLOW_ERROR_MSG = "Airflow responded with an error:"
 DATA_DOES_NOT_EXIST_MSG = "The data entity does not exist on the database"
 
 # Conditional endpoints
-CONDITIONAL_ENDPOINTS = {
+CONDITIONAL_ENDPOINTS_BASE_CLASS = {
+    "signup": SignUpEndpoint,
+    "login": LoginEndpoint,
+}
+
+CONDITIONAL_ENDPOINTS_URLS = {
     "signup": "/signup/",
     "login": "/login/",
 }

--- a/cornflow-server/cornflow/shared/utils_tables.py
+++ b/cornflow-server/cornflow/shared/utils_tables.py
@@ -91,9 +91,13 @@ def get_all_tables():
                 for col in model.__dict__["__table__"]._columns
             }
             for typeclass, convert_to_int in type_converter.items():
-                if isinstance(props["id"].type, typeclass):
-                    tables[model.__tablename__]["convert_id"] = convert_to_int
-                    break
+                if "id" in props:
+                    if isinstance(props["id"].type, typeclass):
+                        tables[model.__tablename__]["convert_id"] = convert_to_int
+                        break
+                else:
+                    tables[model.__tablename__]["convert_id"] = False
+
         except AttributeError:
             pass
     return tables

--- a/cornflow-server/cornflow/tests/unit/test_cli.py
+++ b/cornflow-server/cornflow/tests/unit/test_cli.py
@@ -327,7 +327,7 @@ class CLITests(TestCase):
         self.assertEqual(len(actions), 5)
         self.assertEqual(len(roles), 4)
         self.assertEqual(len(views), (len(resources) + len(alarms_resources)))
-        self.assertEqual(len(permissions), 583)
+        self.assertEqual(len(permissions), 573)
 
     def test_permissions_base_command(self):
         """
@@ -353,7 +353,7 @@ class CLITests(TestCase):
         self.assertEqual(len(actions), 5)
         self.assertEqual(len(roles), 4)
         self.assertEqual(len(views), (len(resources) + len(alarms_resources)))
-        self.assertEqual(len(permissions), 583)
+        self.assertEqual(len(permissions), 573)
 
     def test_service_entrypoint(self):
         """

--- a/cornflow-server/cornflow/tests/unit/test_get_resources.py
+++ b/cornflow-server/cornflow/tests/unit/test_get_resources.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 from flask import Flask
 from cornflow.endpoints import get_resources, resources
-from cornflow.shared.const import CONDITIONAL_ENDPOINTS
+from cornflow.shared.const import CONDITIONAL_ENDPOINTS_URLS
 
 
 class TestGetResources(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestGetResources(unittest.TestCase):
                 )
                 self.assertIsNotNone(signup_resource)
                 self.assertEqual(
-                    signup_resource["urls"], CONDITIONAL_ENDPOINTS["signup"]
+                    signup_resource["urls"], CONDITIONAL_ENDPOINTS_URLS["signup"]
                 )
                 self.assertEqual(
                     signup_resource["resource"], self.mock_signup_view.view_class
@@ -74,9 +74,11 @@ class TestGetResources(unittest.TestCase):
                 self.assertIsNotNone(signup_resource)
                 self.assertIsNotNone(login_resource)
                 self.assertEqual(
-                    signup_resource["urls"], CONDITIONAL_ENDPOINTS["signup"]
+                    signup_resource["urls"], CONDITIONAL_ENDPOINTS_URLS["signup"]
                 )
-                self.assertEqual(login_resource["urls"], CONDITIONAL_ENDPOINTS["login"])
+                self.assertEqual(
+                    login_resource["urls"], CONDITIONAL_ENDPOINTS_URLS["login"]
+                )
 
     def test_does_not_add_duplicate_endpoints(self):
         """Test that get_resources does not add endpoints that already exist in base resources"""

--- a/cornflow-server/cornflow/tests/unit/test_tables.py
+++ b/cornflow-server/cornflow/tests/unit/test_tables.py
@@ -17,7 +17,7 @@ from cornflow.tests.const import LOGIN_URL, SIGNUP_URL, TABLES_URL
 
 class TestTablesListEndpoint(TestCase):
     def create_app(self):
-        app = create_app("testing")
+        app = create_app("testing-table-endpoints")
         return app
 
     def setUp(self):

--- a/cornflow-server/cornflow/tests/unit/test_tables.py
+++ b/cornflow-server/cornflow/tests/unit/test_tables.py
@@ -121,7 +121,7 @@ class TestTablesListEndpoint(TestCase):
 
 class TestTablesDetailEndpoint(TestCase):
     def create_app(self):
-        app = create_app("testing")
+        app = create_app("testing-table-endpoints")
         return app
 
     def setUp(self):
@@ -225,7 +225,7 @@ class TestTablesDetailEndpoint(TestCase):
 
 class TestTablesEndpointAdmin(TestCase):
     def create_app(self):
-        app = create_app("testing")
+        app = create_app("testing-table-endpoints")
         return app
 
     def setUp(self):


### PR DESCRIPTION
Table endpoints have to be activated on purpose to be used.
Added a new check on the `get_all_tables` in case tables on the external app do not use an `id` column.