### PR TITLE
Security: require admin/service passwords instead of hardcoded defaults

### DIFF
--- a/cornflow-server/cornflow/cli/service.py
+++ b/cornflow-server/cornflow/cli/service.py
@@ -197,12 +197,22 @@ def _setup_environment_variables():
     cornflow_admin_email = os.getenv(
         "CORNFLOW_ADMIN_EMAIL", "cornflow_admin@cornflow.com"
     )
-    cornflow_admin_pwd = os.getenv("CORNFLOW_ADMIN_PWD", "Cornflow_admin1234")
+    cornflow_admin_pwd = os.getenv("CORNFLOW_ADMIN_PWD")
+    if not cornflow_admin_pwd:
+        sys.exit(
+            "FATAL: CORNFLOW_ADMIN_PWD must be set. "
+            "Refusing to start with a default admin password."
+        )
     cornflow_service_user = os.getenv("CORNFLOW_SERVICE_USER", "service_user")
     cornflow_service_email = os.getenv(
         "CORNFLOW_SERVICE_EMAIL", "service_user@cornflow.com"
     )
-    cornflow_service_pwd = os.getenv("CORNFLOW_SERVICE_PWD", "Service_user1234")
+    cornflow_service_pwd = os.getenv("CORNFLOW_SERVICE_PWD")
+    if not cornflow_service_pwd:
+        sys.exit(
+            "FATAL: CORNFLOW_SERVICE_PWD must be set. "
+            "Refusing to start with a default service-user password."
+        )
 
     # Cornflow logging and deployment config
     cornflow_logging = os.getenv("CORNFLOW_LOGGING", "console")


### PR DESCRIPTION
## Problem
`cornflow/cli/service.py` fell back to hardcoded passwords for the bootstrap admin and service users when the env vars were not set:

```python
cornflow_admin_pwd = os.getenv("CORNFLOW_ADMIN_PWD", "Cornflow_admin1234")
cornflow_service_pwd = os.getenv("CORNFLOW_SERVICE_PWD", "Service_user1234")
```

Combined with `SERVICE_USER_ALLOW_PASSWORD_LOGIN=1` (default), any operator who forgot to set these env vars would boot a server with publicly-known admin credentials — trivial full compromise of an exposed API.

## Fix
The service now refuses to start unless `CORNFLOW_ADMIN_PWD` and `CORNFLOW_SERVICE_PWD` are explicitly provided, exiting with a clear `FATAL` message otherwise. No default passwords remain.

## Impact / migration
Deployments that relied on the implicit defaults must now set `CORNFLOW_ADMIN_PWD` and `CORNFLOW_SERVICE_PWD`. This is intentional hardening.