### PR TITLE
Security: default OPEN_DEPLOYMENT to closed

### DIFF
--- a/cornflow-server/cornflow/cli/service.py
+++ b/cornflow-server/cornflow/cli/service.py
@@ -207,7 +207,7 @@ def _setup_environment_variables():
     # Cornflow logging and deployment config
     cornflow_logging = os.getenv("CORNFLOW_LOGGING", "console")
     os.environ["CORNFLOW_LOGGING"] = cornflow_logging
-    open_deployment = os.getenv("OPEN_DEPLOYMENT", 1)
+    open_deployment = os.getenv("OPEN_DEPLOYMENT", 0)
     os.environ["OPEN_DEPLOYMENT"] = str(open_deployment)
     signup_activated = os.getenv("SIGNUP_ACTIVATED", SIGNUP_WITH_AUTH)
     os.environ["SIGNUP_ACTIVATED"] = str(signup_activated)

--- a/cornflow-server/cornflow/config.py
+++ b/cornflow-server/cornflow/config.py
@@ -57,7 +57,7 @@ class DefaultConfig(object):
     )
 
     # Open deployment (all dags accessible to all users)
-    OPEN_DEPLOYMENT = os.getenv("OPEN_DEPLOYMENT", 1)
+    OPEN_DEPLOYMENT = os.getenv("OPEN_DEPLOYMENT", 0)
 
     # Planner users can access objects of other users (1) or not(0).
     USER_ACCESS_ALL_OBJECTS = os.getenv(


### PR DESCRIPTION
## Problem
`OPEN_DEPLOYMENT` defaulted to `1` in both `config.py` and `cli/service.py`. With open deployment:
- `Auth.dag_permission_required` is short-circuited, so every authenticated user can run every DAG.
- New OID / sign-up users are auto-granted all DAG permissions.

For an internet-exposed or multi-tenant deployment this disables per-DAG authorization entirely, by default.

## Fix
Default `OPEN_DEPLOYMENT` to `0` (closed) in both places. The `Testing` config still sets it to `1` explicitly so the test suite is unaffected.

## Impact / migration
Deployments that intentionally want all DAGs open to all users must now set `OPEN_DEPLOYMENT=1` explicitly. Existing per-DAG permission grants continue to work.