### PR TITLE
Security/bug: strengthen password policy and fix letterless-password gap

### DIFF
--- a/cornflow-server/cornflow/shared/validators.py
+++ b/cornflow-server/cornflow/shared/validators.py
@@ -31,21 +31,16 @@ def check_password_pattern(password: str):
     # TODO: handle better None passwords that can be found when using ldap
     if password is None:
         return True, None
-    if len(password) < 5:
-        return False, "Password must contain at least 5 characters."
-    if password.islower() or password.isupper():
-        return False, "Password must contain uppercase and lowercase letters."
-    if len(list(filter(str.isdigit, password))) == 0:
-        return (
-            False,
-            "Password must contain at least one number and one special character.",
-        )
-
-    if len(list(filter(is_special_character, password))) == 0:
-        return (
-            False,
-            "Password must contain at least one number and one special character.",
-        )
+    if len(password) < 12:
+        return False, "Password must contain at least 12 characters."
+    if not any(char.islower() for char in password):
+        return False, "Password must contain at least one lowercase letter."
+    if not any(char.isupper() for char in password):
+        return False, "Password must contain at least one uppercase letter."
+    if not any(char.isdigit() for char in password):
+        return False, "Password must contain at least one number."
+    if not any(is_special_character(char) for char in password):
+        return False, "Password must contain at least one special character."
 
     return True, None
 


### PR DESCRIPTION
## Problems
`check_password_pattern` in `cornflow/shared/validators.py` had two issues:

1. **Logic bug:** the mixed-case check was `if password.islower() or password.isupper()`. For a string with *no* cased characters, both return `False`, so the check passed. A password with no letters at all (e.g. `12345!`) was accepted despite the intent to require upper- and lower-case letters.
2. **Weak minimum:** the minimum length was only 5 characters.

## Fix
Rewrote the validator to:
- require at least **12 characters**;
- explicitly require at least one lowercase letter, one uppercase letter, one digit, and one special character, using per-character `any()` checks (so letterless passwords are correctly rejected).

The existing `UserModel.generate_random_password()` already produces passwords that satisfy these rules, so password-recovery is unaffected.

## Impact
New/changed passwords must meet the stronger policy. Existing stored hashes are unaffected.