### PR TITLE
Security: disable password-recovery endpoint by default (interim mitigation)

### DIFF
--- a/cornflow-server/cornflow/config.py
+++ b/cornflow-server/cornflow/config.py
@@ -102,6 +102,11 @@ class DefaultConfig(object):
     # compress config
     COMPRESS_REGISTER = False
 
+    # Password recovery endpoint. Disabled by default: when enabled, the current
+    # endpoint resets the user's password on an unauthenticated request, which
+    # allows account-lockout abuse. Keep off until the token-based flow lands.
+    PASSWORD_RECOVERY_ENABLED = int(os.getenv("PASSWORD_RECOVERY_ENABLED", 0))
+
     # Email server
     SERVICE_EMAIL_ADDRESS = os.getenv("SERVICE_EMAIL_ADDRESS", None)
     SERVICE_EMAIL_PASSWORD = os.getenv("SERVICE_EMAIL_PASSWORD", None)

--- a/cornflow-server/cornflow/endpoints/user.py
+++ b/cornflow-server/cornflow/endpoints/user.py
@@ -258,6 +258,13 @@ class RecoverPassword(BaseMetaResource):
         :rtype: Tuple(dict, integer)
         """
 
+        if not current_app.config.get("PASSWORD_RECOVERY_ENABLED"):
+            raise EndpointNotImplemented(
+                "Password recovery is disabled on this deployment.",
+                log_txt="Password recovery request rejected: feature is disabled "
+                "(PASSWORD_RECOVERY_ENABLED is not set).",
+            )
+
         sender = current_app.config["SERVICE_EMAIL_ADDRESS"]
         password = current_app.config["SERVICE_EMAIL_PASSWORD"]
         smtp_server = current_app.config["SERVICE_EMAIL_SERVER"]


### PR DESCRIPTION
## Problem
`RecoverPassword` (`/user/recover-password/`) immediately generates a new random password and **overwrites the target user's password** on an unauthenticated request, with no rate limiting. Anyone who knows a user's email can lock that user out at will (account-lockout DoS) and mail-bomb them.

## Fix (interim, smallest change)
Gate the endpoint behind a new `PASSWORD_RECOVERY_ENABLED` config flag, **default off**. When disabled the endpoint returns `501`/not-implemented and changes nothing. This removes the vulnerability from default deployments without a schema change.

## Follow-up
The proper fix — a token-based reset flow (email a time-limited link, confirm before changing the password) — is tracked in a separate issue and will supersede this flag.

## Impact / migration
Deployments that intentionally use the current recovery behaviour must set `PASSWORD_RECOVERY_ENABLED=1`.