### PR TITLE
Security: honor CORS_ORIGINS instead of hardcoded wildcard

### DIFF
--- a/cornflow-server/cornflow/app.py
+++ b/cornflow-server/cornflow/app.py
@@ -69,7 +69,12 @@ def create_app(env_name="development", dataconn=None):
     # initialization for init_cornflow_service.py
     if dataconn is not None:
         app.config["SQLALCHEMY_DATABASE_URI"] = dataconn
-    CORS(app)
+    cors_origins = app.config.get("CORS_ORIGINS", "*")
+    if isinstance(cors_origins, str) and cors_origins != "*":
+        cors_origins = [
+            origin.strip() for origin in cors_origins.split(",") if origin.strip()
+        ]
+    CORS(app, origins=cors_origins)
     bcrypt.init_app(app)
     db.init_app(app)
     Migrate(app=app, db=db)


### PR DESCRIPTION
## Problem
`app.py` initialized CORS with `CORS(app)` and no arguments, which allows **all** origins and silently ignored the `CORS_ORIGINS` config value that the project already defines. The intended origin allow-list was never applied.

(Impact is limited because authentication is a `Bearer` header rather than cookies, so this is not a direct CSRF vector — but the configured restriction simply did not take effect.)

## Fix
CORS is now configured from `CORS_ORIGINS`:
- a single origin or a comma-separated list is parsed and passed to `flask-cors`;
- the default remains `*`, so behaviour is unchanged unless an allow-list is configured.

## Impact / migration
Set `CORS_ORIGINS=https://app.example.com,https://admin.example.com` (etc.) to restrict origins. Leaving it unset keeps the previous permissive behaviour.