### PR TITLE
Security: add expiry to BI tokens

### DIFF
--- a/cornflow-server/cornflow/config.py
+++ b/cornflow-server/cornflow/config.py
@@ -124,6 +124,9 @@ class DefaultConfig(object):
     # Token duration in hours
     TOKEN_DURATION = os.getenv("TOKEN_DURATION", 24)
 
+    # BI token duration in hours
+    BI_TOKEN_DURATION = os.getenv("BI_TOKEN_DURATION", 24)
+
     # Password rotation time in days
     PWD_ROTATION_TIME = os.getenv("PWD_ROTATION_TIME", 120)
 

--- a/cornflow-server/cornflow/shared/authentication/auth.py
+++ b/cornflow-server/cornflow/shared/authentication/auth.py
@@ -473,7 +473,7 @@ class BIAuth(Auth):
     def generate_token(user_id: int = None) -> str:
         """
         Generates a token given a user_id. The token will contain the username in the sub claim.
-        BI tokens do not include expiration time.
+        BI tokens expire after BI_TOKEN_DURATION hours.
 
         :param int user_id: user id to generate the token for
         :return: the generated token
@@ -493,6 +493,8 @@ class BIAuth(Auth):
             )
 
         payload = {
+            "exp": datetime.now(timezone.utc)
+            + timedelta(hours=float(current_app.config["BI_TOKEN_DURATION"])),
             "iat": datetime.now(timezone.utc),
             "sub": user.username,
             "iss": INTERNAL_TOKEN_ISSUER,


### PR DESCRIPTION
## Problem
`BIAuth.generate_token` (`shared/authentication/auth.py`) built its payload without an `exp` claim, so BI tokens never expired. A leaked BI token would remain valid indefinitely with no way to age it out.

## Fix
- Add an `exp` claim, controlled by a new `BI_TOKEN_DURATION` config value (hours, default 24).
- `BIAuth.decode_token` already uses `jwt.decode`, which enforces `exp` automatically, so expired BI tokens are now rejected.
- Updated the docstring accordingly.

## Impact / migration
BI tokens now expire after `BI_TOKEN_DURATION` hours. Set that env var to tune the lifetime for your BI integration.