### PR TITLE
Hardening: add timeout to OIDC JWKS fetch

### DIFF
--- a/cornflow-server/cornflow/shared/authentication/auth.py
+++ b/cornflow-server/cornflow/shared/authentication/auth.py
@@ -316,7 +316,7 @@ class Auth:
             jwks_url = f"{provider_url.rstrip('/')}/.well-known/jwks.json"
 
         try:
-            response = requests.get(jwks_url)
+            response = requests.get(jwks_url, timeout=10)
             response.raise_for_status()
 
             # Convert JWK to RSA public keys using PyJWT's built-in method


### PR DESCRIPTION
## Problem
`Auth.get_public_keys` fetched the provider's JWKS with `requests.get(jwks_url)` and **no timeout**. A slow or unresponsive OIDC provider could block a gunicorn worker indefinitely during token verification — a denial-of-service amplifier.

## Fix
Add a 10-second timeout to the request. A timeout raises `requests.exceptions.RequestException`, which is already handled and surfaced as `CommunicationError`.