### PR TITLE
Hardening: disable SQLALCHEMY_TRACK_MODIFICATIONS by default

### DIFF
--- a/cornflow-server/cornflow/config.py
+++ b/cornflow-server/cornflow/config.py
@@ -29,7 +29,7 @@ class DefaultConfig(object):
     AUTH_TYPE = int(os.getenv("AUTH_TYPE", AUTH_DB))
     DEFAULT_ROLE = int(os.getenv("DEFAULT_ROLE", PLANNER_ROLE))
     CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*")
-    SQLALCHEMY_TRACK_MODIFICATIONS = True
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
     DEBUG = True
     TESTING = True
     LOG_LEVEL = int(os.getenv("LOG_LEVEL", 20))


### PR DESCRIPTION
## Problem
`DefaultConfig` enabled `SQLALCHEMY_TRACK_MODIFICATIONS`, which Flask-SQLAlchemy itself recommends disabling: it adds memory/CPU overhead and is unused by cornflow. The `Testing` and `Production` configs already set it to `False`, so `DefaultConfig`/`Development` were the inconsistent outliers.

## Fix
Default `SQLALCHEMY_TRACK_MODIFICATIONS = False` in `DefaultConfig`.

## Impact
No functional change; removes the tracking overhead and the Flask-SQLAlchemy startup warning.