### PR TITLE
Bug: remove duplicate email body attachment

### DIFF
--- a/cornflow-server/cornflow/shared/email.py
+++ b/cornflow-server/cornflow/shared/email.py
@@ -32,7 +32,6 @@ def get_email(text: str, subject: str, sender: str, receiver: str):
     t = MIMEText(body, "html")
 
     email.attach(t)
-    email.attach(t)
 
     return email.as_string()
 


### PR DESCRIPTION
## Problem
`get_email` in `cornflow/shared/email.py` attached the same `MIMEText` body twice:

```python
t = MIMEText(body, "html")
email.attach(t)
email.attach(t)   # duplicate
```

The resulting message carried two identical HTML parts — rendered twice by some clients and treated as malformed by others.

## Fix
Attach the body once.