### PR TITLE
Bug: validate Databricks env vars with a clear error

### DIFF
--- a/cornflow-server/cornflow/cli/service.py
+++ b/cornflow-server/cornflow/cli/service.py
@@ -158,12 +158,25 @@ def _setup_environment_variables():
         os.environ["AIRFLOW_PWD"] = airflow_pwd
         os.environ["AIRFLOW_URL"] = airflow_url
     elif cornflow_backend == DATABRICKS_BACKEND:
+        required_databricks_vars = [
+            "DATABRICKS_HOST",
+            "DATABRICKS_CLIENT_SECRET",
+            "DATABRICKS_TOKEN_ENDPOINT",
+            "DATABRICKS_EP_CLUSTERS",
+            "DATABRICKS_CLIENT_ID",
+        ]
+        missing = [var for var in required_databricks_vars if not os.getenv(var)]
+        if missing:
+            sys.exit(
+                "FATAL: the Databricks backend requires the following environment "
+                f"variables to be set: {', '.join(missing)}"
+            )
         databricks_url = os.getenv("DATABRICKS_HOST")
         databricks_auth_secret = os.getenv("DATABRICKS_CLIENT_SECRET")
         databricks_token_endpoint = os.getenv("DATABRICKS_TOKEN_ENDPOINT")
         databricks_ep_clusters = os.getenv("DATABRICKS_EP_CLUSTERS")
         databricks_client_id = os.getenv("DATABRICKS_CLIENT_ID")
-        databricks_health_path = os.getenv("DATABRICKS_HEALTH_PATH")
+        databricks_health_path = os.getenv("DATABRICKS_HEALTH_PATH", "default path")
         os.environ["DATABRICKS_HEALTH_PATH"] = databricks_health_path
         os.environ["DATABRICKS_HOST"] = databricks_url
         os.environ["DATABRICKS_CLIENT_SECRET"] = databricks_auth_secret


### PR DESCRIPTION
## Problem
In `_setup_environment_variables`, when `CORNFLOW_BACKEND` selects Databricks, the `DATABRICKS_*` variables were read with `os.getenv()` (no default) and then assigned into `os.environ`:

```python
databricks_url = os.getenv("DATABRICKS_HOST")     # None if unset
...
os.environ["DATABRICKS_HOST"] = databricks_url    # TypeError if None
```

If any required var was unset, this raised an opaque `TypeError: str expected, not NoneType` instead of a meaningful message.

## Fix
Validate the required Databricks variables up front and `sys.exit` with a `FATAL` message listing the missing ones. `DATABRICKS_HEALTH_PATH` falls back to the same `"default path"` default already used in `config.py`.

## Impact
Misconfigured Databricks deployments now fail with an actionable message rather than a confusing stack trace.