### PR TITLE
Bug: guard put_detail/patch_detail against missing user kwarg

### DIFF
--- a/cornflow-server/cornflow/endpoints/meta_resource.py
+++ b/cornflow-server/cornflow/endpoints/meta_resource.py
@@ -146,7 +146,8 @@ class BaseMetaResource(Resource, MethodResource):
         data = dict(data)
 
         if track_user:
-            user_id = kwargs.get("user").get("id") or self.get_user_id()
+            user = kwargs.get("user")
+            user_id = (user.get("id") if user is not None else None) or self.get_user_id()
             data["user_id"] = user_id
 
         item.update(data)
@@ -169,7 +170,8 @@ class BaseMetaResource(Resource, MethodResource):
         data = dict(data)
 
         if track_user:
-            user_id = kwargs.get("user").get("id") or self.get_user_id()
+            user = kwargs.get("user")
+            user_id = (user.get("id") if user is not None else None) or self.get_user_id()
             data["user_id"] = user_id
 
         item.patch(data)


### PR DESCRIPTION
## Problem
`put_detail` and `patch_detail` in `endpoints/meta_resource.py` computed:

```python
user_id = kwargs.get("user").get("id") or self.get_user_id()
```

When `track_user` is True (the default) but no `user` kwarg is supplied, `kwargs.get("user")` is `None`, so `None.get("id")` raises `AttributeError`. Current callers happen to always pass `user`, so it is latent — but it is a fragile default.

## Fix
Read the `user` kwarg defensively and fall back to `self.get_user_id()` when it is absent:

```python
user = kwargs.get("user")
user_id = (user.get("id") if user is not None else None) or self.get_user_id()
```

Applied to both methods.