### PR TITLE
Cleanup: use execution-state constants instead of magic numbers

### DIFF
--- a/cornflow-server/cornflow/endpoints/execution.py
+++ b/cornflow-server/cornflow/endpoints/execution.py
@@ -406,7 +406,7 @@ class ExecutionRelaunchEndpoint(OrchestratorMixin):
         )
 
         # If the execution is still running or queued, raise an error
-        if execution.state == 0 or execution.state == -7:
+        if execution.state in (EXEC_STATE_RUNNING, EXEC_STATE_QUEUED):
             return {"message": "This execution is still running"}, 400
 
         # this allows testing without airflow interaction:


### PR DESCRIPTION
## Problem
In `ExecutionRelaunchEndpoint.post` the still-running check used literals:

```python
if execution.state == 0 or execution.state == -7:
```

`0` is `EXEC_STATE_RUNNING` and `-7` is `EXEC_STATE_QUEUED` — both already imported in the module. The literals work today but would silently drift if the constants change.

## Fix
```python
if execution.state in (EXEC_STATE_RUNNING, EXEC_STATE_QUEUED):
```

No behavioural change.