### PR TITLE
Enhanced logging configuration through environment variables￼

### DIFF
--- a/cornflow-server/cornflow/cli/service.py
+++ b/cornflow-server/cornflow/cli/service.py
@@ -223,7 +223,9 @@ def _setup_environment_variables():
     os.environ["OPEN_DEPLOYMENT"] = str(open_deployment)
     signup_activated = os.getenv("SIGNUP_ACTIVATED", SIGNUP_WITH_AUTH)
     os.environ["SIGNUP_ACTIVATED"] = str(signup_activated)
-    user_access_all_objects = os.getenv("USER_ACCESS_ALL_OBJECTS", USER_ACCESS_ALL_OBJECTS_NO)
+    user_access_all_objects = os.getenv(
+        "USER_ACCESS_ALL_OBJECTS", USER_ACCESS_ALL_OBJECTS_NO
+    )
     os.environ["USER_ACCESS_ALL_OBJECTS"] = str(user_access_all_objects)
     default_role = int(os.getenv("DEFAULT_ROLE", PLANNER_ROLE))
     os.environ["DEFAULT_ROLE"] = str(default_role)
@@ -242,26 +244,26 @@ def _setup_environment_variables():
     external_application = int(os.getenv("EXTERNAL_APP", 0))
     external_app_module = os.getenv("EXTERNAL_APP_MODULE")
     base_dict = {
-            "environment": environment,
-            "auth": auth,
-            "cornflow_db_conn": cornflow_db_conn,
-            "cornflow_admin_user": cornflow_admin_user,
-            "cornflow_admin_email": cornflow_admin_email,
-            "cornflow_admin_pwd": cornflow_admin_pwd,
-            "cornflow_service_user": cornflow_service_user,
-            "cornflow_service_email": cornflow_service_email,
-            "cornflow_service_pwd": cornflow_service_pwd,
-            "cornflow_logging": cornflow_logging,
-            "open_deployment": open_deployment,
-            "external_application": external_application,
-            "external_app_module": external_app_module,
-            "cornflow_backend": cornflow_backend,
-        }
+        "environment": environment,
+        "auth": auth,
+        "cornflow_db_conn": cornflow_db_conn,
+        "cornflow_admin_user": cornflow_admin_user,
+        "cornflow_admin_email": cornflow_admin_email,
+        "cornflow_admin_pwd": cornflow_admin_pwd,
+        "cornflow_service_user": cornflow_service_user,
+        "cornflow_service_email": cornflow_service_email,
+        "cornflow_service_pwd": cornflow_service_pwd,
+        "cornflow_logging": cornflow_logging,
+        "open_deployment": open_deployment,
+        "external_application": external_application,
+        "external_app_module": external_app_module,
+        "cornflow_backend": cornflow_backend,
+    }
     if cornflow_backend == AIRFLOW_BACKEND:
         base_dict["airflow_user"] = airflow_user
         base_dict["airflow_pwd"] = airflow_pwd
         base_dict["airflow_url"] = airflow_url
-    
+
     elif cornflow_backend == DATABRICKS_BACKEND:
         base_dict["databricks_url"] = databricks_url
         base_dict["databricks_auth_secret"] = databricks_auth_secret
@@ -269,7 +271,7 @@ def _setup_environment_variables():
         base_dict["databricks_ep_clusters"] = databricks_ep_clusters
         base_dict["databricks_client_id"] = databricks_client_id
         base_dict["databricks_health_path"] = databricks_health_path
-        
+
     else:
         raise Exception("Selected backend not among valid options")
 

--- a/cornflow-server/cornflow/cli/service.py
+++ b/cornflow-server/cornflow/cli/service.py
@@ -5,14 +5,26 @@ import time
 import logging
 from logging import error
 
+from cornflow.shared.log_config import JsonFormatter
+
 # Configure a logger for the service module
 logger = logging.getLogger("cornflow.service")
 logger.setLevel(logging.INFO)
 
 # Add console handler if not already present
 if not logger.handlers:
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(asctime)s [%(name)s] [%(levelname)s] %(message)s")
+    stream = (
+        sys.stderr
+        if os.getenv("CORNFLOW_LOG_STREAM", "stdout").lower() == "stderr"
+        else sys.stdout
+    )
+    handler = logging.StreamHandler(stream)
+    if os.getenv("CORNFLOW_LOG_FORMAT", "text").lower() == "json":
+        formatter = JsonFormatter()
+    else:
+        formatter = logging.Formatter(
+            "%(asctime)s [%(name)s] [%(levelname)s] %(message)s"
+        )
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.propagate = False

--- a/cornflow-server/cornflow/gunicorn.py
+++ b/cornflow-server/cornflow/gunicorn.py
@@ -1,4 +1,5 @@
 """gunicorn WSGI server configuration."""
+
 import os
 from multiprocessing import cpu_count
 

--- a/cornflow-server/cornflow/gunicorn.py
+++ b/cornflow-server/cornflow/gunicorn.py
@@ -2,6 +2,8 @@
 import os
 from multiprocessing import cpu_count
 
+from cornflow.shared.log_config import gunicorn_log_config
+
 
 def max_workers():
     return cpu_count()
@@ -21,3 +23,8 @@ log_level = "info"
 if os.getenv("CORNFLOW_LOGGING") == "file":
     accesslog = "/usr/src/app/log/info.log"
     errorlog = "/usr/src/app/log/error.log"
+else:
+    # error and access logs share stream (CORNFLOW_LOG_STREAM), format
+    # (CORNFLOW_LOG_FORMAT) and cloud shipping with the application logs
+    accesslog = "-"
+    logconfig_dict = gunicorn_log_config()

--- a/cornflow-server/cornflow/shared/cloud_logging.py
+++ b/cornflow-server/cornflow/shared/cloud_logging.py
@@ -27,7 +27,9 @@ class BufferedCloudHandler(logging.Handler):
     Subclasses must implement :meth:`_upload` and :meth:`destination`.
     """
 
-    def __init__(self, bucket, prefix="cornflow-logs", upload_interval=60, max_buffer=5000):
+    def __init__(
+        self, bucket, prefix="cornflow-logs", upload_interval=60, max_buffer=5000
+    ):
         super().__init__()
         self.bucket = bucket
         self.prefix = str(prefix).strip("/")

--- a/cornflow-server/cornflow/shared/cloud_logging.py
+++ b/cornflow-server/cornflow/shared/cloud_logging.py
@@ -1,0 +1,183 @@
+"""
+Logging handlers that buffer records in memory and periodically upload them
+as objects to a cloud storage bucket (AWS S3 or Google Cloud Storage).
+
+These handlers are activated through environment variables (see
+:func:`cornflow.shared.log_config.log_config`) and are meant as a complement
+to console logging: records are always written to stdout/stderr as well, so
+a crash can at most lose the records buffered since the last upload.
+"""
+
+import atexit
+import logging
+import os
+import socket
+import sys
+import threading
+import uuid
+from datetime import datetime, timezone
+
+
+class BufferedCloudHandler(logging.Handler):
+    """
+    Base handler that accumulates formatted records in memory and flushes
+    them as a single object to a bucket, either every ``upload_interval``
+    seconds or as soon as ``max_buffer`` records are queued.
+
+    Subclasses must implement :meth:`_upload` and :meth:`destination`.
+    """
+
+    def __init__(self, bucket, prefix="cornflow-logs", upload_interval=60, max_buffer=5000):
+        super().__init__()
+        self.bucket = bucket
+        self.prefix = str(prefix).strip("/")
+        self.upload_interval = max(int(upload_interval), 1)
+        self.max_buffer = max(int(max_buffer), 1)
+        self._buffer = []
+        self._buffer_lock = threading.Lock()
+        self._hostname = socket.gethostname()
+        self._flusher = None
+        self._flusher_pid = None
+        self._stop = threading.Event()
+        atexit.register(self.flush)
+
+    def emit(self, record):
+        try:
+            message = self.format(record)
+            self._ensure_flusher()
+            with self._buffer_lock:
+                self._buffer.append(message)
+                must_flush = len(self._buffer) >= self.max_buffer
+            if must_flush:
+                self.flush()
+        except Exception:
+            self.handleError(record)
+
+    def _ensure_flusher(self):
+        # threads do not survive a fork (gunicorn pre-fork model), so the
+        # flusher is (re)started lazily in the process that emits records
+        if (
+            self._flusher is not None
+            and self._flusher.is_alive()
+            and self._flusher_pid == os.getpid()
+        ):
+            return
+        with self._buffer_lock:
+            if (
+                self._flusher is not None
+                and self._flusher.is_alive()
+                and self._flusher_pid == os.getpid()
+            ):
+                return
+            self._flusher_pid = os.getpid()
+            self._stop = threading.Event()
+            self._flusher = threading.Thread(
+                target=self._flush_loop, daemon=True, name="cornflow-log-uploader"
+            )
+            self._flusher.start()
+
+    def _flush_loop(self):
+        while not self._stop.wait(self.upload_interval):
+            self.flush()
+
+    def flush(self):
+        with self._buffer_lock:
+            if not self._buffer:
+                return
+            data, self._buffer = self._buffer, []
+        try:
+            self._upload("\n".join(data) + "\n")
+        except Exception as error:
+            # log shipping must never crash the application: requeue the
+            # records (dropping the oldest beyond max_buffer) and report
+            sys.stderr.write(
+                f"cornflow: could not upload logs to {self.destination()}: {error}\n"
+            )
+            with self._buffer_lock:
+                self._buffer = (data + self._buffer)[-self.max_buffer :]
+
+    def _object_name(self):
+        now = datetime.now(timezone.utc)
+        return (
+            f"{self.prefix}/{now:%Y-%m-%d}/{self._hostname}"
+            f"-{os.getpid()}-{now:%H%M%S}-{uuid.uuid4().hex[:8]}.log"
+        )
+
+    def close(self):
+        self._stop.set()
+        try:
+            self.flush()
+        finally:
+            super().close()
+
+    def destination(self):
+        raise NotImplementedError
+
+    def _upload(self, data):
+        raise NotImplementedError
+
+
+class S3LogHandler(BufferedCloudHandler):
+    """
+    Ships buffered log records to an AWS S3 bucket. Requires ``boto3`` and
+    credentials resolved the standard way (env variables, instance profile,
+    IRSA...).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._client = None
+        self._client_pid = None
+
+    def destination(self):
+        return f"s3://{self.bucket}"
+
+    def _get_client(self):
+        if self._client is None or self._client_pid != os.getpid():
+            try:
+                import boto3
+            except ImportError as error:
+                raise RuntimeError(
+                    "boto3 is required to ship logs to S3 (pip install cornflow[s3-logs])"
+                ) from error
+            self._client = boto3.client("s3")
+            self._client_pid = os.getpid()
+        return self._client
+
+    def _upload(self, data):
+        self._get_client().put_object(
+            Bucket=self.bucket, Key=self._object_name(), Body=data.encode("utf-8")
+        )
+
+
+class GCSLogHandler(BufferedCloudHandler):
+    """
+    Ships buffered log records to a Google Cloud Storage bucket. Requires
+    ``google-cloud-storage`` and credentials resolved the standard way
+    (GOOGLE_APPLICATION_CREDENTIALS, workload identity...).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._client = None
+        self._client_pid = None
+
+    def destination(self):
+        return f"gs://{self.bucket}"
+
+    def _get_client(self):
+        if self._client is None or self._client_pid != os.getpid():
+            try:
+                from google.cloud import storage
+            except ImportError as error:
+                raise RuntimeError(
+                    "google-cloud-storage is required to ship logs to GCS "
+                    "(pip install cornflow[gcs-logs])"
+                ) from error
+            self._client = storage.Client()
+            self._client_pid = os.getpid()
+        return self._client
+
+    def _upload(self, data):
+        blob = self._get_client().bucket(self.bucket).blob(self._object_name())
+        blob.upload_from_string(data, content_type="text/plain")

--- a/cornflow-server/cornflow/shared/log_config.py
+++ b/cornflow-server/cornflow/shared/log_config.py
@@ -1,4 +1,19 @@
+"""
+Logging configuration for cornflow, driven by environment variables:
 
+- ``CORNFLOW_LOG_STREAM``: ``stdout`` (default) or ``stderr``.
+- ``CORNFLOW_LOG_FORMAT``: ``text`` (default) or ``json`` (one JSON object per line).
+- ``CORNFLOW_LOG_S3_BUCKET``: if set, logs are also shipped to this S3 bucket.
+- ``CORNFLOW_LOG_GCS_BUCKET``: if set, logs are also shipped to this GCS bucket.
+- ``CORNFLOW_LOG_UPLOAD_PREFIX``: object key prefix for shipped logs (default ``cornflow-logs``).
+- ``CORNFLOW_LOG_UPLOAD_INTERVAL``: seconds between uploads (default 60).
+- ``CORNFLOW_LOG_UPLOAD_MAX_BUFFER``: records that force an immediate upload (default 5000).
+"""
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
 
 LEVEL_CONVERTER = {
     0: "NOTSET",
@@ -6,23 +21,109 @@ LEVEL_CONVERTER = {
     20: "INFO",
     30: "WARNING",
     40: "ERROR",
-    50: "CRITICAL"
+    50: "CRITICAL",
 }
+
+TEXT_FORMAT = "[%(asctime)s] [%(levelname)s] in %(module)s: %(message)s"
+
+
+class JsonFormatter(logging.Formatter):
+    """Formats each record as a single-line JSON object, for log collectors."""
+
+    def format(self, record):
+        entry = {
+            "timestamp": datetime.fromtimestamp(
+                record.created, tz=timezone.utc
+            ).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "module": record.module,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            entry["exception"] = self.formatException(record.exc_info)
+        return json.dumps(entry, ensure_ascii=False, default=str)
+
+
+def get_formatter_config():
+    log_format = os.getenv("CORNFLOW_LOG_FORMAT", "text").lower()
+    if log_format == "json":
+        return {"()": "cornflow.shared.log_config.JsonFormatter"}
+    return {"format": TEXT_FORMAT}
+
+
+def get_console_stream():
+    stream = os.getenv("CORNFLOW_LOG_STREAM", "stdout").lower()
+    return "ext://sys.stderr" if stream == "stderr" else "ext://sys.stdout"
+
+
+def get_cloud_handlers_config():
+    """
+    Returns the handlers configuration for shipping logs to S3 and/or GCS,
+    according to the environment variables. Empty if none is configured.
+    """
+    common = {
+        "formatter": "default",
+        "prefix": os.getenv("CORNFLOW_LOG_UPLOAD_PREFIX", "cornflow-logs"),
+        "upload_interval": int(os.getenv("CORNFLOW_LOG_UPLOAD_INTERVAL", 60)),
+        "max_buffer": int(os.getenv("CORNFLOW_LOG_UPLOAD_MAX_BUFFER", 5000)),
+    }
+    handlers = {}
+    s3_bucket = os.getenv("CORNFLOW_LOG_S3_BUCKET")
+    if s3_bucket:
+        handlers["cloud_s3"] = {
+            "()": "cornflow.shared.cloud_logging.S3LogHandler",
+            "bucket": s3_bucket,
+            **common,
+        }
+    gcs_bucket = os.getenv("CORNFLOW_LOG_GCS_BUCKET")
+    if gcs_bucket:
+        handlers["cloud_gcs"] = {
+            "()": "cornflow.shared.cloud_logging.GCSLogHandler",
+            "bucket": gcs_bucket,
+            **common,
+        }
+    return handlers
 
 
 def log_config(level=20):
-    return {
-        'version': 1,
-        'formatters': {'default': {
-            'format': '[%(asctime)s] [%(levelname)s] in %(module)s: %(message)s',
-        }},
-        'handlers': {'wsgi': {
-            'class': 'logging.StreamHandler',
-            'stream': 'ext://flask.logging.wsgi_errors_stream',
-            'formatter': 'default'
-        }},
-        'root': {
-            'level': LEVEL_CONVERTER[level],
-            'handlers': ['wsgi']
-        }
+    handlers = {
+        "console": {
+            "class": "logging.StreamHandler",
+            "stream": get_console_stream(),
+            "formatter": "default",
+        },
+        **get_cloud_handlers_config(),
     }
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {"default": get_formatter_config()},
+        "handlers": handlers,
+        "root": {
+            "level": LEVEL_CONVERTER[level],
+            "handlers": list(handlers),
+        },
+    }
+
+
+def gunicorn_log_config(level=None):
+    """
+    Logging configuration for gunicorn (``logconfig_dict``) so that its error
+    and access logs share stream, format and cloud shipping with the
+    application logs.
+    """
+    if level is None:
+        level = int(os.getenv("LOG_LEVEL", 20))
+    config = log_config(level)
+    handler_names = list(config["handlers"])
+    config["loggers"] = {
+        name: {
+            "level": config["root"]["level"],
+            "handlers": handler_names,
+            "propagate": False,
+            "qualname": name,
+        }
+        for name in ("gunicorn.error", "gunicorn.access")
+    }
+    return config

--- a/cornflow-server/cornflow/tests/unit/test_log_config.py
+++ b/cornflow-server/cornflow/tests/unit/test_log_config.py
@@ -48,9 +48,7 @@ class TestLogConfig(unittest.TestCase):
     def test_stream_can_be_set_to_stderr(self):
         with patch.dict("os.environ", {"CORNFLOW_LOG_STREAM": "stderr"}):
             config = log_config(20)
-        self.assertEqual(
-            config["handlers"]["console"]["stream"], "ext://sys.stderr"
-        )
+        self.assertEqual(config["handlers"]["console"]["stream"], "ext://sys.stderr")
 
     def test_json_format_uses_json_formatter(self):
         with patch.dict("os.environ", {"CORNFLOW_LOG_FORMAT": "json"}):

--- a/cornflow-server/cornflow/tests/unit/test_log_config.py
+++ b/cornflow-server/cornflow/tests/unit/test_log_config.py
@@ -1,0 +1,185 @@
+"""
+Unit tests for the environment-driven logging configuration
+(cornflow.shared.log_config) and the cloud shipping handlers
+(cornflow.shared.cloud_logging).
+"""
+
+import json
+import logging
+import unittest
+from logging.config import dictConfig
+from unittest.mock import patch
+
+from cornflow.shared.cloud_logging import BufferedCloudHandler
+from cornflow.shared.log_config import (
+    JsonFormatter,
+    gunicorn_log_config,
+    log_config,
+)
+
+
+class FakeCloudHandler(BufferedCloudHandler):
+    """Cloud handler that records uploads instead of sending them."""
+
+    def __init__(self, *args, fail=False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uploads = []
+        self.fail = fail
+
+    def destination(self):
+        return f"fake://{self.bucket}"
+
+    def _upload(self, data):
+        if self.fail:
+            raise RuntimeError("upload failed")
+        self.uploads.append(data)
+
+
+class TestLogConfig(unittest.TestCase):
+    def test_default_config_writes_text_to_stdout(self):
+        with patch.dict("os.environ", {}, clear=True):
+            config = log_config(20)
+        console = config["handlers"]["console"]
+        self.assertEqual(console["stream"], "ext://sys.stdout")
+        self.assertEqual(config["root"]["handlers"], ["console"])
+        self.assertEqual(config["root"]["level"], "INFO")
+        self.assertIn("format", config["formatters"]["default"])
+
+    def test_stream_can_be_set_to_stderr(self):
+        with patch.dict("os.environ", {"CORNFLOW_LOG_STREAM": "stderr"}):
+            config = log_config(20)
+        self.assertEqual(
+            config["handlers"]["console"]["stream"], "ext://sys.stderr"
+        )
+
+    def test_json_format_uses_json_formatter(self):
+        with patch.dict("os.environ", {"CORNFLOW_LOG_FORMAT": "json"}):
+            config = log_config(20)
+        self.assertEqual(
+            config["formatters"]["default"]["()"],
+            "cornflow.shared.log_config.JsonFormatter",
+        )
+
+    def test_cloud_handlers_added_from_environment(self):
+        env = {
+            "CORNFLOW_LOG_S3_BUCKET": "my-s3-bucket",
+            "CORNFLOW_LOG_GCS_BUCKET": "my-gcs-bucket",
+            "CORNFLOW_LOG_UPLOAD_INTERVAL": "30",
+        }
+        with patch.dict("os.environ", env):
+            config = log_config(20)
+        self.assertEqual(config["handlers"]["cloud_s3"]["bucket"], "my-s3-bucket")
+        self.assertEqual(config["handlers"]["cloud_gcs"]["bucket"], "my-gcs-bucket")
+        self.assertEqual(config["handlers"]["cloud_s3"]["upload_interval"], 30)
+        self.assertEqual(
+            sorted(config["root"]["handlers"]),
+            ["cloud_gcs", "cloud_s3", "console"],
+        )
+
+    def test_gunicorn_config_shares_handlers(self):
+        with patch.dict("os.environ", {"CORNFLOW_LOG_S3_BUCKET": "my-s3-bucket"}):
+            config = gunicorn_log_config(20)
+        for name in ("gunicorn.error", "gunicorn.access"):
+            self.assertEqual(
+                sorted(config["loggers"][name]["handlers"]),
+                ["cloud_s3", "console"],
+            )
+            self.assertFalse(config["loggers"][name]["propagate"])
+
+    def test_dict_config_applies_cleanly(self):
+        root = logging.getLogger()
+        previous_handlers, previous_level = root.handlers[:], root.level
+        try:
+            with patch.dict("os.environ", {"CORNFLOW_LOG_FORMAT": "json"}):
+                dictConfig(log_config(20))
+            self.assertTrue(
+                any(isinstance(h.formatter, JsonFormatter) for h in root.handlers)
+            )
+        finally:
+            root.handlers, root.level = previous_handlers, previous_level
+
+
+class TestJsonFormatter(unittest.TestCase):
+    def _record(self, **kwargs):
+        defaults = dict(
+            name="cornflow.test",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg="something happened: %s",
+            args=("detail",),
+            exc_info=None,
+        )
+        defaults.update(kwargs)
+        return logging.LogRecord(**defaults)
+
+    def test_output_is_one_json_object_per_line(self):
+        output = JsonFormatter().format(self._record())
+        self.assertNotIn("\n", output)
+        entry = json.loads(output)
+        self.assertEqual(entry["level"], "WARNING")
+        self.assertEqual(entry["logger"], "cornflow.test")
+        self.assertEqual(entry["message"], "something happened: detail")
+        self.assertIn("timestamp", entry)
+
+    def test_exception_is_included(self):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            record = self._record(exc_info=sys.exc_info())
+        entry = json.loads(JsonFormatter().format(record))
+        self.assertIn("ValueError: boom", entry["exception"])
+
+
+class TestBufferedCloudHandler(unittest.TestCase):
+    def _handler(self, **kwargs):
+        handler = FakeCloudHandler("bucket", upload_interval=3600, **kwargs)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        self.addCleanup(handler.close)
+        return handler
+
+    def _emit(self, handler, message):
+        handler.emit(
+            logging.LogRecord(
+                "cornflow.test", logging.INFO, __file__, 1, message, None, None
+            )
+        )
+
+    def test_records_are_buffered_until_flush(self):
+        handler = self._handler(max_buffer=100)
+        self._emit(handler, "one")
+        self._emit(handler, "two")
+        self.assertEqual(handler.uploads, [])
+        handler.flush()
+        self.assertEqual(handler.uploads, ["one\ntwo\n"])
+        # a second flush with an empty buffer does not upload anything
+        handler.flush()
+        self.assertEqual(len(handler.uploads), 1)
+
+    def test_full_buffer_triggers_upload(self):
+        handler = self._handler(max_buffer=2)
+        self._emit(handler, "one")
+        self._emit(handler, "two")
+        self.assertEqual(handler.uploads, ["one\ntwo\n"])
+
+    def test_failed_upload_requeues_records(self):
+        handler = self._handler(max_buffer=100, fail=True)
+        self._emit(handler, "one")
+        with patch("sys.stderr"):
+            handler.flush()
+        self.assertEqual(handler.uploads, [])
+        handler.fail = False
+        handler.flush()
+        self.assertEqual(handler.uploads, ["one\n"])
+
+    def test_object_names_are_unique(self):
+        handler = self._handler()
+        names = {handler._object_name() for _ in range(50)}
+        self.assertEqual(len(names), 50)
+        self.assertTrue(all(name.startswith("cornflow-logs/") for name in names))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cornflow-server/setup.py
+++ b/cornflow-server/setup.py
@@ -17,6 +17,10 @@ setuptools.setup(
     url="https://github.com/baobabsoluciones/cornflow",
     packages=setuptools.find_packages(),
     install_requires=required,
+    extras_require={
+        "s3-logs": ["boto3"],
+        "gcs-logs": ["google-cloud-storage"],
+    },
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/docs/source/deploy/logs.rst
+++ b/docs/source/deploy/logs.rst
@@ -11,6 +11,60 @@ cornflow logs are written to console output (stdout) by default. In this way you
 
 If you want to know about the possibilities offered by the docker log engine, you can visit the official documentation `here <https://docs.docker.com/engine/reference/commandline/logs/>`_.
 
+Log output configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The destination and format of the logs (application logs and gunicorn access/error logs) can be configured through environment variables:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Variable
+     - Description
+     - Default
+   * - ``CORNFLOW_LOG_STREAM``
+     - Console stream for the logs: ``stdout`` or ``stderr``.
+     - ``stdout``
+   * - ``CORNFLOW_LOG_FORMAT``
+     - ``text`` for plain text or ``json`` for one JSON object per line (recommended for log collectors such as Fluent Bit, CloudWatch or Cloud Logging).
+     - ``text``
+   * - ``LOG_LEVEL``
+     - Minimum level of the records: 10 (debug), 20 (info), 30 (warning), 40 (error), 50 (critical).
+     - ``20``
+
+In JSON mode each line contains the fields ``timestamp`` (ISO 8601, UTC), ``level``, ``logger``, ``module``, ``message`` and, when present, ``exception``.
+
+Shipping logs to S3 or Google Cloud Storage
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In Kubernetes or docker deployments the recommended pattern is to write JSON logs to stdout and let a cluster agent (Fluent Bit, Vector, CloudWatch agent...) ship them to their final destination. Nevertheless, cornflow can also upload the logs directly to a bucket, in addition to the console output:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 45 20
+
+   * - Variable
+     - Description
+     - Default
+   * - ``CORNFLOW_LOG_S3_BUCKET``
+     - Name of the AWS S3 bucket to upload logs to. Requires ``boto3`` (``pip install cornflow[s3-logs]``) and credentials resolved the standard AWS way (environment variables, instance profile, IRSA...).
+     - (disabled)
+   * - ``CORNFLOW_LOG_GCS_BUCKET``
+     - Name of the Google Cloud Storage bucket to upload logs to. Requires ``google-cloud-storage`` (``pip install cornflow[gcs-logs]``) and credentials resolved the standard GCP way (``GOOGLE_APPLICATION_CREDENTIALS``, workload identity...).
+     - (disabled)
+   * - ``CORNFLOW_LOG_UPLOAD_PREFIX``
+     - Key prefix of the uploaded objects.
+     - ``cornflow-logs``
+   * - ``CORNFLOW_LOG_UPLOAD_INTERVAL``
+     - Seconds between uploads.
+     - ``60``
+   * - ``CORNFLOW_LOG_UPLOAD_MAX_BUFFER``
+     - Number of buffered records that forces an immediate upload.
+     - ``5000``
+
+Records are buffered in memory and periodically uploaded as objects named ``{prefix}/{date}/{hostname}-{pid}-{time}-{id}.log``. Note that if a container is killed abruptly, the records buffered since the last upload may be lost (they are still written to the console output).
+
 If you want to activate the persistent log storage in files, you must pass the value ``file`` to the environment variable ``CORNFLOW_LOGGING`` in the cornflow server deployment.
 Once the log storage is activated, these will be saved in the path ``/usr/src/app/log`` inside the cornflow container.
 To permanently store the logs even if the service is destroyed, you can mount a volume against the directory as follows::


### PR DESCRIPTION
  ## Enhanced logging: stdout by default, JSON format and shipping to S3/GCS

  ### Motivation

  Cornflow logs were being written to **stderr** (the app handler used
  `flask.logging.wsgi_errors_stream` and gunicorn's `errorlog` defaults to stderr).
  In docker/K8s deployments this mixes application logs with actual system errors,
  making filtering and alerting harder. There was also no structured (JSON) output
  and no way to persist logs outside the container.

  ### What's new

  All logging behaviour is now configurable **via environment variables** — no code
  or image changes needed per deployment:

  | Variable | Values | Default |
  |---|---|---|
  | `CORNFLOW_LOG_STREAM` | `stdout` / `stderr` | `stdout` |
  | `CORNFLOW_LOG_FORMAT` | `text` / `json` (one JSON object per line) | `text` |
  | `CORNFLOW_LOG_S3_BUCKET` | AWS S3 bucket to ship logs to | disabled |
  | `CORNFLOW_LOG_GCS_BUCKET` | GCS bucket to ship logs to | disabled |
  | `CORNFLOW_LOG_UPLOAD_PREFIX` | object key prefix | `cornflow-logs` |
  | `CORNFLOW_LOG_UPLOAD_INTERVAL` | seconds between uploads | `60` |
  | `CORNFLOW_LOG_UPLOAD_MAX_BUFFER` | records that force an immediate upload | `5000` |

  - **Logs go to stdout by default** instead of stderr.
  - **JSON format** (`CORNFLOW_LOG_FORMAT=json`): each line is a JSON object with
    `timestamp` (ISO 8601, UTC), `level`, `logger`, `module`, `message` and
    `exception` when present — ready for Fluent Bit / CloudWatch / Cloud Logging.
  - **Unified gunicorn logs**: access and error logs share stream, format and cloud
    shipping with the application logs (via `logconfig_dict`).
  - **Optional direct shipping to S3/GCS**: buffered handlers upload batches of
    records as objects named `{prefix}/{date}/{hostname}-{pid}-{time}-{id}.log`.
    Handlers are fork-safe (flusher thread restarts after gunicorn forks), never
    crash the app on upload failures (records are re-queued with a cap), and flush
    on shutdown. Dependencies are optional extras: `cornflow[s3-logs]` (boto3) and
    `cornflow[gcs-logs]` (google-cloud-storage).

  ### Changes

  - `cornflow/shared/log_config.py`: rewritten; env-driven dict config, `JsonFormatter`,
    `gunicorn_log_config()`.
  - `cornflow/shared/cloud_logging.py` (new): `BufferedCloudHandler`, `S3LogHandler`,
    `GCSLogHandler`.
  - `cornflow/gunicorn.py`: unified logging via `logconfig_dict`; enables the access log.
  - `cornflow/cli/service.py`: startup logger honours the same variables.
  - `setup.py`: `s3-logs` / `gcs-logs` extras.
  - `docs/source/deploy/logs.rst`: new configuration reference.
  - `cornflow/tests/unit/test_log_config.py` (new): 12 unit tests.

  ### Backwards compatibility

  - The legacy `CORNFLOW_LOGGING=file` mode (log files + logrotate) is unchanged.
  - Default format remains plain text with the same layout; `LOG_LEVEL` works as before.
  - ⚠️  Behaviour change: logs now go to **stdout** by default instead of stderr. Set
    `CORNFLOW_LOG_STREAM=stderr` to restore the previous behaviour.

  ### Testing

  - 12 new unit tests covering config building, the JSON formatter and the buffered
    handler (buffering, forced flush, re-queue on upload failure, unique object names).
  - Manual smoke test: app + `gunicorn.access` records emitted as valid JSON to stdout.
  - End-to-end test with `moto` (mocked S3): records appear on the console **and** are
    uploaded to the bucket by the background flusher with the expected content.

  ### Note for reviewers

  Direct-to-bucket shipping is complementary to console output, not a replacement: if a
  container is killed abruptly, records buffered since the last upload are lost (but they
  were already written to stdout). For K8s the recommended production pattern remains
  `CORNFLOW_LOG_FORMAT=json` + a log collector agent, as documented.