### PR TITLE
Fix 'click' dependency version in Airflow Dockerfile

### DIFF
--- a/cornflow-server/airflow_config/Dockerfile
+++ b/cornflow-server/airflow_config/Dockerfile
@@ -20,7 +20,7 @@ ENV AIRFLOW_HOME=${AIRFLOW_USER_HOME}
 # install Airflow and extras: celery,postgres and redis
 RUN pip install "apache-airflow[amazon,celery,google,postgres,redis,sendgrid]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 # We add these overruns due to security reasons as suggested here: https://airflow.apache.org/docs/apache-airflow/stable/installation/installing-from-pypi.html#upgrading-and-installing-dependencies-including-providers
-RUN pip install "apache-airflow[amazon,celery,google,postgres,redis,sendgrid]==${AIRFLOW_VERSION}" "cryptography==48.0.1" "requests==2.31.0" "Werkzeug==2.3.8"
+RUN pip install "apache-airflow[amazon,celery,google,postgres,redis,sendgrid]==${AIRFLOW_VERSION}" "cryptography==48.0.1" "requests==2.31.0" "Werkzeug==2.3.8" "click==8.1.7"
 
 # copy init script and config to container
 COPY scripts ${AIRFLOW_HOME}/scripts


### PR DESCRIPTION
Fix bug when using click 8.4.0 with celery executor.
Airflow 2.9.1 constraints set it to 8.1.7