### PR TITLE
Route DAG/instance/execution/case data endpoints to raw-JSON variants

### DIFF
--- a/cornflow-server/cornflow/endpoints/__init__.py
+++ b/cornflow-server/cornflow/endpoints/__init__.py
@@ -14,12 +14,12 @@ from .case import (
     CaseFromInstanceExecutionEndpoint,
     CaseCopyEndpoint,
     CaseDetailsEndpoint,
-    CaseDataEndpoint,
+    CaseDataEndpointRaw,
     CaseToInstance,
     CaseCompare,
 )
 from .dag import (
-    DAGDetailEndpoint,
+    DAGDetailEndpointRaw,
     DAGEndpointManual,
     DAGCaseEndpoint,
     DAGInstanceEndpoint,
@@ -36,7 +36,7 @@ from .execution import (
     ExecutionEndpoint,
     ExecutionDetailsEndpoint,
     ExecutionStatusEndpoint,
-    ExecutionDataEndpoint,
+    ExecutionDataEndpointRaw,
     ExecutionLogEndpoint,
     ExecutionRelaunchEndpoint,
     ExecutionFilesEndpoint,
@@ -47,7 +47,7 @@ from .instance import (
     InstanceEndpoint,
     InstanceDetailsEndpoint,
     InstanceFileEndpoint,
-    InstanceDataEndpoint,
+    InstanceDataEndpointRaw,
 )
 from .licenses import LicensesEndpoint
 from .main_alarms import MainAlarmsEndpoint
@@ -67,7 +67,7 @@ resources = [
         endpoint="instances-detail",
     ),
     dict(
-        resource=InstanceDataEndpoint,
+        resource=InstanceDataEndpointRaw,
         urls="/instance/<string:idx>/data/",
         endpoint="instances-data",
     ),
@@ -115,7 +115,7 @@ resources = [
         endpoint="execution-status",
     ),
     dict(
-        resource=ExecutionDataEndpoint,
+        resource=ExecutionDataEndpointRaw,
         urls="/execution/<string:idx>/data/",
         endpoint="execution-data",
     ),
@@ -132,7 +132,7 @@ resources = [
     dict(resource=ExecutionEndpoint, urls="/execution/", endpoint="execution"),
     dict(resource=ExecutionFilesEndpoint, urls="/execution/files/<string:idx>/", endpoint="execution-files"),
     dict(resource=ExecutionFilesCleanupEndpoint, urls="/execution/files/cleanup/", endpoint="execution-files-cleanup"),
-    dict(resource=DAGDetailEndpoint, urls="/dag/<string:idx>/", endpoint="dag"),
+    dict(resource=DAGDetailEndpointRaw, urls="/dag/<string:idx>/", endpoint="dag"),
     dict(resource=DAGEndpointManual, urls="/dag/", endpoint="dag-manual"),
     dict(
         resource=DAGInstanceEndpoint,
@@ -187,7 +187,9 @@ resources = [
     dict(resource=CaseCopyEndpoint, urls="/case/<int:idx>/copy/", endpoint="case-copy"),
     dict(resource=CaseEndpoint, urls="/case/", endpoint="case"),
     dict(resource=CaseDetailsEndpoint, urls="/case/<int:idx>/", endpoint="case-detail"),
-    dict(resource=CaseDataEndpoint, urls="/case/<int:idx>/data/", endpoint="case-data"),
+    dict(
+        resource=CaseDataEndpointRaw, urls="/case/<int:idx>/data/", endpoint="case-data"
+    ),
     dict(
         resource=CaseToInstance,
         urls="/case/<int:idx>/instance/",

--- a/cornflow-server/cornflow/endpoints/case.py
+++ b/cornflow-server/cornflow/endpoints/case.py
@@ -5,16 +5,22 @@ These endpoints have different access url, but manage the same data entities
 """
 
 # Import from libraries
+import json
+from types import SimpleNamespace
+
 from cornflow_client.constants import INSTANCE_SCHEMA, SOLUTION_SCHEMA
 from flask import current_app
 from flask_apispec import marshal_with, use_kwargs, doc
 from flask_inflate import inflate
 import jsonpatch
+from sqlalchemy import cast
 
 
 # Import from internal modules
 from cornflow.endpoints.meta_resource import BaseMetaResource
+from cornflow.endpoints.raw_json import raw_json_object_response, restrict_to_owner
 from cornflow.models import CaseModel, ExecutionModel, DeployedWorkflow, InstanceModel
+from cornflow.shared import db
 from cornflow.shared.authentication import Auth, authenticate
 from cornflow.shared.compress import compressed
 from cornflow.shared.const import VIEWER_ROLE, PLANNER_ROLE, ADMIN_ROLE
@@ -313,7 +319,12 @@ class CaseDetailsEndpoint(BaseMetaResource):
 
 class CaseDataEndpoint(CaseDetailsEndpoint):
     """
-    Endpoint used to get the data of a given case
+    DEPRECATED: superseded by :class:`CaseDataEndpointRaw`, which is now
+    routed at this endpoint's former URL. Not routed anymore -- kept
+    around because :class:`CaseDataEndpointRaw` inherits its ``put``,
+    ``delete`` and ``patch`` from here (via :class:`CaseDetailsEndpoint`
+    and this class respectively), and for the benchmark scripts in
+    ``cornflow.tests.load`` that compare it against the optimized variant.
     """
 
     ROLES_WITH_ACCESS = [VIEWER_ROLE, PLANNER_ROLE, ADMIN_ROLE]
@@ -346,6 +357,114 @@ class CaseDataEndpoint(CaseDetailsEndpoint):
         response = self.patch_detail(data=kwargs, idx=idx, user=self.get_user())
         current_app.logger.info(f"User {self.get_user()} patches case {idx}")
         return response
+
+
+class CaseDataEndpointRaw(CaseDataEndpoint):
+    """
+    Raw-JSON-passthrough variant of :class:`CaseDataEndpoint`'s GET, now
+    routed at ``/case/<idx>/data/`` in place of it. Inherits ``put``,
+    ``delete`` and ``patch`` unchanged from :class:`CaseDataEndpoint`.
+
+    ``data``, ``checks``, ``solution_checks`` and ``kpis`` are returned
+    completely verbatim, so those are cast to text at the SQL layer and
+    spliced straight into the response, skipping decode+re-encode of them
+    entirely.
+
+    ``solution`` still needs to be decoded once, since ``indicators`` is
+    derived from ``solution["indicators"]`` -- but the already-fetched raw
+    text is spliced back in for the ``solution`` field itself rather than
+    re-serializing the decoded dict, so the re-encode half of the round
+    trip is still skipped.
+    """
+
+    ROLES_WITH_ACCESS = [VIEWER_ROLE, PLANNER_ROLE, ADMIN_ROLE]
+
+    @doc(
+        description="Get data of a case (raw JSON passthrough)",
+        tags=["Cases"],
+        inherit=False,
+    )
+    @authenticate(auth_class=Auth())
+    @compressed
+    def get(self, idx):
+        """
+        Same response contract as :meth:`CaseDataEndpoint.get`.
+
+        :param int idx: ID of the case
+        :return: the case data (body) and an integer HTTP status code
+        :rtype: `flask.Response`
+        """
+        query = db.session.query(
+            CaseModel.id,
+            CaseModel.name,
+            CaseModel.description,
+            CaseModel.created_at,
+            CaseModel.updated_at,
+            CaseModel.user_id,
+            CaseModel.data_hash,
+            CaseModel.schema,
+            CaseModel.path,
+            CaseModel.solution_hash,
+            cast(CaseModel.data, db.Text),
+            cast(CaseModel.checks, db.Text),
+            cast(CaseModel.solution, db.Text),
+            cast(CaseModel.solution_checks, db.Text),
+            cast(CaseModel.kpis, db.Text),
+        ).filter(CaseModel.id == idx, CaseModel.deleted_at.is_(None))
+        query = restrict_to_owner(query, CaseModel, self.get_user())
+        row = query.first()
+        if row is None:
+            raise ObjectDoesNotExist()
+        (
+            case_id,
+            name,
+            description,
+            created_at,
+            updated_at,
+            user_id,
+            data_hash,
+            schema,
+            path,
+            solution_hash,
+            data_raw,
+            checks_raw,
+            solution_raw,
+            solution_checks_raw,
+            kpis_raw,
+        ) = row
+
+        solution_decoded = (
+            json.loads(solution_raw) if solution_raw is not None else None
+        )
+        current_app.logger.info(f"User {self.get_user()} gets case {idx}")
+        small_fields = CaseListAllWithIndicators().dump(
+            SimpleNamespace(
+                id=case_id,
+                name=name,
+                description=description,
+                created_at=created_at,
+                updated_at=updated_at,
+                user_id=user_id,
+                data_hash=data_hash,
+                schema=schema,
+                path=path,
+                solution_hash=solution_hash,
+                # only used by is_dir's `obj.data is None` check
+                data=data_raw,
+                # used by indicators' `obj.solution[...]` access
+                solution=solution_decoded,
+            )
+        )
+        return raw_json_object_response(
+            [(key, value, False) for key, value in small_fields.items()]
+            + [
+                ("data", data_raw, True),
+                ("checks", checks_raw, True),
+                ("solution", solution_raw, True),
+                ("solution_checks", solution_checks_raw, True),
+                ("kpis", kpis_raw, True),
+            ]
+        )
 
 
 class CaseToInstance(BaseMetaResource):

--- a/cornflow-server/cornflow/endpoints/dag.py
+++ b/cornflow-server/cornflow/endpoints/dag.py
@@ -7,9 +7,11 @@ These are the endpoints used by airflow in its communication with cornflow
 from cornflow_client.constants import SOLUTION_SCHEMA
 from flask import current_app
 from flask_apispec import use_kwargs, doc, marshal_with
+from sqlalchemy import cast
 
 # Import from internal modules
 from cornflow.endpoints.meta_resource import BaseMetaResource
+from cornflow.endpoints.raw_json import raw_json_object_response
 from cornflow.models import DeployedWorkflow, ExecutionModel, InstanceModel, CaseModel
 from cornflow.schemas import DeployedDAGSchema, DeployedDAGEditSchema
 from cornflow.schemas.case import CaseChecksKPIsRequest
@@ -20,6 +22,7 @@ from cornflow.schemas.execution import (
     ExecutionDetailsEndpointResponse,
 )
 
+from cornflow.shared import db
 from cornflow.shared.authentication import Auth, authenticate
 from cornflow.shared.const import (
     ADMIN_ROLE,
@@ -35,7 +38,11 @@ from cornflow.shared.validators import json_schema_validate_as_string
 
 class DAGDetailEndpoint(BaseMetaResource):
     """
-    Endpoint used for the DAG endpoint
+    DEPRECATED: superseded by :class:`DAGDetailEndpointRaw`, which is now
+    routed at this endpoint's former URL. Not routed anymore -- kept
+    around because :class:`DAGDetailEndpointRaw` inherits its ``put`` from
+    here, and for the benchmark scripts in ``cornflow.tests.load`` that
+    compare it against the optimized variants.
     """
 
     ROLES_WITH_ACCESS = [ADMIN_ROLE, SERVICE_ROLE]
@@ -151,6 +158,139 @@ class DAGDetailEndpoint(BaseMetaResource):
 
         current_app.logger.info(f"User {self.get_user()} edits execution {idx}")
         return {"message": "results successfully saved"}, 200
+
+
+class DAGDetailEndpointFast(BaseMetaResource):
+    """
+    DEPRECATED: intermediate optimization step, superseded by
+    :class:`DAGDetailEndpointRaw` (a further-optimized variant that
+    also skips JSON decode/encode on the huge columns, which this one
+    still pays for). Not routed -- kept only for the benchmark scripts
+    in ``cornflow.tests.load`` that compare it against the other variants.
+
+    Fetches only the columns needed for the response with a single
+    SQLAlchemy Core-style JOIN query, instead of loading two full ORM
+    objects (which also pull in unused heavy columns like ``checks``,
+    ``kpis``, ``log_text`` and ``log_json``).
+    """
+
+    ROLES_WITH_ACCESS = [ADMIN_ROLE, SERVICE_ROLE]
+
+    @doc(
+        description="Get input data and configuration for an execution (optimized)",
+        tags=["DAGs"],
+    )
+    @authenticate(auth_class=Auth())
+    def get(self, idx):
+        """
+        API method to get the data of the instance that is going to be executed.
+        Same response contract as :meth:`DAGDetailEndpoint.get`.
+
+        :param str idx: ID of the execution
+        :return: the execution data (body) in a dictionary with structure of :class:`ConfigSchema`
+          and :class:`DataSchema` and an integer for HTTP status code
+        :rtype: Tuple(dict, integer)
+        """
+        row = (
+            db.session.query(
+                InstanceModel.id,
+                InstanceModel.data,
+                ExecutionModel.data,
+                ExecutionModel.config,
+            )
+            .join(ExecutionModel, ExecutionModel.instance_id == InstanceModel.id)
+            .filter(
+                ExecutionModel.id == idx,
+                ExecutionModel.deleted_at.is_(None),
+                InstanceModel.deleted_at.is_(None),
+            )
+            .first()
+        )
+        if row is None:
+            err = "The execution does not exist."
+            raise ObjectDoesNotExist(
+                error=err,
+                log_txt=f"Error while user {self.get_user()} tries to get input data for execution {idx}."
+                + err,
+            )
+        instance_id, instance_data, solution_data, config = row
+        current_app.logger.info(
+            f"User {self.get_user()} gets input data of execution {idx}"
+        )
+        return {
+            "id": instance_id,
+            "data": instance_data,
+            "solution_data": solution_data,
+            "config": config,
+        }, 200
+
+
+class DAGDetailEndpointRaw(DAGDetailEndpoint):
+    """
+    Further-optimized variant of :class:`DAGDetailEndpointFast`'s GET, now
+    routed at ``/dag/<idx>/`` in place of :class:`DAGDetailEndpoint`.
+    Inherits ``put`` unchanged from :class:`DAGDetailEndpoint`.
+
+    ``data``, ``solution_data`` and ``config`` are returned completely
+    verbatim by this endpoint (no server-side transformation), so the
+    normal decode-into-Python / re-encode-to-JSON round trip on those
+    columns is pure overhead. This variant casts them to text at the SQL
+    layer -- so SQLAlchemy never runs ``json.loads`` on them -- and
+    splices that already-valid JSON text directly into a hand-built
+    response body via :func:`raw_json_object_response`.
+    """
+
+    ROLES_WITH_ACCESS = [ADMIN_ROLE, SERVICE_ROLE]
+
+    @doc(
+        description="Get input data and configuration for an execution (raw JSON passthrough)",
+        tags=["DAGs"],
+    )
+    @authenticate(auth_class=Auth())
+    def get(self, idx):
+        """
+        API method to get the data of the instance that is going to be executed.
+        Same response contract as :meth:`DAGDetailEndpoint.get`.
+
+        :param str idx: ID of the execution
+        :return: the execution data (body) in a dictionary with structure of :class:`ConfigSchema`
+          and :class:`DataSchema` and an integer for HTTP status code
+        :rtype: `flask.Response`
+        """
+        row = (
+            db.session.query(
+                InstanceModel.id,
+                cast(InstanceModel.data, db.Text),
+                cast(ExecutionModel.data, db.Text),
+                cast(ExecutionModel.config, db.Text),
+            )
+            .join(ExecutionModel, ExecutionModel.instance_id == InstanceModel.id)
+            .filter(
+                ExecutionModel.id == idx,
+                ExecutionModel.deleted_at.is_(None),
+                InstanceModel.deleted_at.is_(None),
+            )
+            .first()
+        )
+        if row is None:
+            err = "The execution does not exist."
+            raise ObjectDoesNotExist(
+                error=err,
+                log_txt=f"Error while user {self.get_user()} tries to get input data for execution {idx}."
+                + err,
+            )
+        instance_id, instance_data_raw, solution_data_raw, config_raw = row
+        current_app.logger.info(
+            f"User {self.get_user()} gets input data of execution {idx}"
+        )
+        return raw_json_object_response(
+            [
+                ("id", instance_id, False),
+                ("data", instance_data_raw, True),
+                ("solution_data", solution_data_raw, True),
+                ("config", config_raw, True),
+            ]
+        )
 
 
 class DAGInstanceEndpoint(BaseMetaResource):

--- a/cornflow-server/cornflow/endpoints/dag.py
+++ b/cornflow-server/cornflow/endpoints/dag.py
@@ -160,76 +160,11 @@ class DAGDetailEndpoint(BaseMetaResource):
         return {"message": "results successfully saved"}, 200
 
 
-class DAGDetailEndpointFast(BaseMetaResource):
-    """
-    DEPRECATED: intermediate optimization step, superseded by
-    :class:`DAGDetailEndpointRaw` (a further-optimized variant that
-    also skips JSON decode/encode on the huge columns, which this one
-    still pays for). Not routed -- kept only for the benchmark scripts
-    in ``cornflow.tests.load`` that compare it against the other variants.
-
-    Fetches only the columns needed for the response with a single
-    SQLAlchemy Core-style JOIN query, instead of loading two full ORM
-    objects (which also pull in unused heavy columns like ``checks``,
-    ``kpis``, ``log_text`` and ``log_json``).
-    """
-
-    ROLES_WITH_ACCESS = [ADMIN_ROLE, SERVICE_ROLE]
-
-    @doc(
-        description="Get input data and configuration for an execution (optimized)",
-        tags=["DAGs"],
-    )
-    @authenticate(auth_class=Auth())
-    def get(self, idx):
-        """
-        API method to get the data of the instance that is going to be executed.
-        Same response contract as :meth:`DAGDetailEndpoint.get`.
-
-        :param str idx: ID of the execution
-        :return: the execution data (body) in a dictionary with structure of :class:`ConfigSchema`
-          and :class:`DataSchema` and an integer for HTTP status code
-        :rtype: Tuple(dict, integer)
-        """
-        row = (
-            db.session.query(
-                InstanceModel.id,
-                InstanceModel.data,
-                ExecutionModel.data,
-                ExecutionModel.config,
-            )
-            .join(ExecutionModel, ExecutionModel.instance_id == InstanceModel.id)
-            .filter(
-                ExecutionModel.id == idx,
-                ExecutionModel.deleted_at.is_(None),
-                InstanceModel.deleted_at.is_(None),
-            )
-            .first()
-        )
-        if row is None:
-            err = "The execution does not exist."
-            raise ObjectDoesNotExist(
-                error=err,
-                log_txt=f"Error while user {self.get_user()} tries to get input data for execution {idx}."
-                + err,
-            )
-        instance_id, instance_data, solution_data, config = row
-        current_app.logger.info(
-            f"User {self.get_user()} gets input data of execution {idx}"
-        )
-        return {
-            "id": instance_id,
-            "data": instance_data,
-            "solution_data": solution_data,
-            "config": config,
-        }, 200
-
-
 class DAGDetailEndpointRaw(DAGDetailEndpoint):
     """
-    Further-optimized variant of :class:`DAGDetailEndpointFast`'s GET, now
-    routed at ``/dag/<idx>/`` in place of :class:`DAGDetailEndpoint`.
-    Inherits ``put`` unchanged from :class:`DAGDetailEndpoint`.
+    Optimized variant of :class:`DAGDetailEndpoint`'s GET, now routed at
+    ``/dag/<idx>/`` in place of it. Inherits ``put`` unchanged from
+    :class:`DAGDetailEndpoint`.
 
     ``data``, ``solution_data`` and ``config`` are returned completely
     verbatim by this endpoint (no server-side transformation), so the

--- a/cornflow-server/cornflow/endpoints/execution.py
+++ b/cornflow-server/cornflow/endpoints/execution.py
@@ -8,6 +8,7 @@ These endpoints hve different access url, but manage the same data entities
 from datetime import datetime, timedelta, timezone
 from flask import request, current_app, make_response, send_file
 from flask_apispec import marshal_with, use_kwargs, doc
+from sqlalchemy import cast
 
 import os
 import time
@@ -20,6 +21,7 @@ from cornflow_client.constants import INSTANCE_SCHEMA, CONFIG_SCHEMA, SOLUTION_S
 
 # Import from internal modules
 from cornflow.endpoints.meta_resource import BaseMetaResource
+from cornflow.endpoints.raw_json import raw_json_object_response, restrict_to_owner
 from cornflow.models import InstanceModel, DeployedWorkflow, ExecutionModel
 from cornflow.schemas.execution import (
     ExecutionDetailsEndpointResponse,
@@ -36,6 +38,8 @@ from cornflow.schemas.execution import (
     ExecutionDetailsWithIndicatorsAndLogResponse,
     ExecutionFilesPostRequest,
 )
+from cornflow.schemas.solution_log import BasicLogSchema
+from cornflow.shared import db
 from cornflow.shared.authentication import Auth, authenticate
 from cornflow.shared.compress import compressed
 from cornflow.shared.const import (
@@ -721,7 +725,10 @@ class ExecutionStatusEndpoint(OrchestratorMixin):
 
 class ExecutionDataEndpoint(ExecutionDetailsEndpointBase):
     """
-    Endpoint used to get the solution of a certain execution.
+    DEPRECATED: superseded by :class:`ExecutionDataEndpointRaw`, which is
+    now routed at this endpoint's former URL. Not routed anymore -- kept
+    only for the benchmark scripts in ``cornflow.tests.load`` that compare
+    it against the optimized variant.
     """
 
     @doc(
@@ -743,6 +750,108 @@ class ExecutionDataEndpoint(ExecutionDetailsEndpointBase):
         """
         current_app.logger.info(f"User {self.get_user()} gets data of execution {idx}")
         return self.get_detail(user=self.get_user(), idx=idx)
+
+
+class ExecutionDataEndpointRaw(ExecutionDataEndpoint):
+    """
+    Raw-JSON-passthrough variant of :class:`ExecutionDataEndpoint`'s GET,
+    now routed at ``/execution/<idx>/data/`` in place of it.
+
+    ``data``, ``checks`` and ``kpis`` are returned completely verbatim, so
+    this variant casts them to text at the SQL layer -- skipping the
+    normal JSON decode -- and splices that already-valid JSON text
+    directly into a hand-built response body via
+    :func:`raw_json_object_response`.
+
+    ``log`` is derived from ``log_json`` by filtering it down to a handful
+    of known keys (see `BasicLogSchema`), so it must stay decoded -- there
+    is nothing to skip there. ``log_text`` isn't part of this endpoint's
+    response at all, so it is never even selected.
+    """
+
+    @doc(
+        description="Get solution data of an execution (raw JSON passthrough)",
+        tags=["Executions"],
+        inherit=False,
+    )
+    @authenticate(auth_class=Auth())
+    @compressed
+    def get(self, idx):
+        """
+        Same response contract as :meth:`ExecutionDataEndpoint.get`.
+
+        :param str idx: ID of the execution.
+        :return: the execution data (body) and an integer HTTP status code
+        :rtype: `flask.Response`
+        """
+        query = db.session.query(
+            ExecutionModel.id,
+            ExecutionModel.name,
+            ExecutionModel.description,
+            ExecutionModel.created_at,
+            ExecutionModel.user_id,
+            ExecutionModel.data_hash,
+            ExecutionModel.schema,
+            ExecutionModel.config,
+            ExecutionModel.instance_id,
+            ExecutionModel.state,
+            ExecutionModel.state_message,
+            ExecutionModel.log_json,
+            cast(ExecutionModel.data, db.Text),
+            cast(ExecutionModel.checks, db.Text),
+            cast(ExecutionModel.kpis, db.Text),
+        ).filter(
+            ExecutionModel.id == idx,
+            ExecutionModel.deleted_at.is_(None),
+        )
+        query = restrict_to_owner(query, ExecutionModel, self.get_user())
+        row = query.first()
+        if row is None:
+            raise ObjectDoesNotExist()
+        (
+            execution_id,
+            name,
+            description,
+            created_at,
+            user_id,
+            data_hash,
+            schema,
+            config,
+            instance_id,
+            state,
+            state_message,
+            log_json,
+            data_raw,
+            checks_raw,
+            kpis_raw,
+        ) = row
+        current_app.logger.info(f"User {self.get_user()} gets data of execution {idx}")
+        small_fields = ExecutionDataEndpointResponse(
+            exclude=("data", "checks", "kpis")
+        ).dump(
+            dict(
+                id=execution_id,
+                name=name,
+                description=description,
+                created_at=created_at,
+                user_id=user_id,
+                data_hash=data_hash,
+                schema=schema,
+                config=config,
+                instance_id=instance_id,
+                state=state,
+                state_message=state_message,
+                log_json=log_json,
+            )
+        )
+        return raw_json_object_response(
+            [(key, value, False) for key, value in small_fields.items()]
+            + [
+                ("data", data_raw, True),
+                ("checks", checks_raw, True),
+                ("kpis", kpis_raw, True),
+            ]
+        )
 
 
 class ExecutionLogEndpoint(ExecutionDetailsEndpointBase):

--- a/cornflow-server/cornflow/endpoints/instance.py
+++ b/cornflow-server/cornflow/endpoints/instance.py
@@ -12,10 +12,12 @@ from flask_inflate import inflate
 from marshmallow.exceptions import ValidationError
 import os
 import pulp
+from sqlalchemy import cast
 from werkzeug.utils import secure_filename
 
 # Import from internal modules
 from cornflow.endpoints.meta_resource import BaseMetaResource
+from cornflow.endpoints.raw_json import raw_json_object_response, restrict_to_owner
 from cornflow.models import InstanceModel, DeployedWorkflow
 from cornflow.schemas.instance import (
     InstanceSchema,
@@ -28,9 +30,10 @@ from cornflow.schemas.instance import (
     QueryFiltersInstance,
 )
 
+from cornflow.shared import db
 from cornflow.shared.authentication import Auth, authenticate
 from cornflow.shared.compress import compressed
-from cornflow.shared.exceptions import InvalidUsage, InvalidData
+from cornflow.shared.exceptions import InvalidUsage, InvalidData, ObjectDoesNotExist
 from cornflow.shared.validators import json_schema_validate_as_string
 
 
@@ -206,7 +209,10 @@ class InstanceDetailsEndpoint(InstanceDetailsEndpointBase):
 
 class InstanceDataEndpoint(InstanceDetailsEndpointBase):
     """
-    Endpoint used to get the information o fa single instance, edit it or delete it
+    DEPRECATED: superseded by :class:`InstanceDataEndpointRaw`, which is
+    now routed at this endpoint's former URL. Not routed anymore -- kept
+    only for the benchmark scripts in ``cornflow.tests.load`` that compare
+    it against the optimized variant.
     """
 
     def __init__(self):
@@ -234,6 +240,84 @@ class InstanceDataEndpoint(InstanceDetailsEndpointBase):
             f"User {self.get_user()} gets the data of instance {idx}"
         )
         return response
+
+
+class InstanceDataEndpointRaw(InstanceDataEndpoint):
+    """
+    Raw-JSON-passthrough variant of :class:`InstanceDataEndpoint`'s GET,
+    now routed at ``/instance/<idx>/data/`` in place of it.
+
+    ``data`` and ``checks`` are returned completely verbatim, so this
+    variant casts them to text at the SQL layer -- skipping the normal
+    JSON decode -- and splices that already-valid JSON text directly
+    into a hand-built response body via :func:`raw_json_object_response`.
+    """
+
+    @doc(
+        description="Get input data of an instance (raw JSON passthrough)",
+        tags=["Instances"],
+        inherit=False,
+    )
+    @authenticate(auth_class=Auth())
+    @compressed
+    def get(self, idx):
+        """
+        Same response contract as :meth:`InstanceDataEndpoint.get`.
+
+        :param str idx: ID of the instance
+        :return: the instance data (body) and an integer HTTP status code
+        :rtype: `flask.Response`
+        """
+        query = db.session.query(
+            InstanceModel.id,
+            InstanceModel.name,
+            InstanceModel.description,
+            InstanceModel.created_at,
+            InstanceModel.user_id,
+            InstanceModel.data_hash,
+            InstanceModel.schema,
+            cast(InstanceModel.data, db.Text),
+            cast(InstanceModel.checks, db.Text),
+        ).filter(
+            InstanceModel.id == idx,
+            InstanceModel.deleted_at.is_(None),
+        )
+        query = restrict_to_owner(query, InstanceModel, self.get_user())
+        row = query.first()
+        if row is None:
+            raise ObjectDoesNotExist()
+        (
+            instance_id,
+            name,
+            description,
+            created_at,
+            user_id,
+            data_hash,
+            schema,
+            data_raw,
+            checks_raw,
+        ) = row
+        current_app.logger.info(
+            f"User {self.get_user()} gets the data of instance {idx}"
+        )
+        small_fields = InstanceEndpointResponse().dump(
+            dict(
+                id=instance_id,
+                name=name,
+                description=description,
+                created_at=created_at,
+                user_id=user_id,
+                data_hash=data_hash,
+                schema=schema,
+            )
+        )
+        return raw_json_object_response(
+            [(key, value, False) for key, value in small_fields.items()]
+            + [
+                ("data", data_raw, True),
+                ("checks", checks_raw, True),
+            ]
+        )
 
 
 class InstanceFileEndpoint(BaseMetaResource):

--- a/cornflow-server/cornflow/endpoints/raw_json.py
+++ b/cornflow-server/cornflow/endpoints/raw_json.py
@@ -26,11 +26,11 @@ def restrict_to_owner(query, model, user):
 
     :param query: a SQLAlchemy query/session.query(...) object
     :param model: the model class being queried (must have `user_id`)
-    :param user: the requesting `UserModel`, or None
+    :param user: the requesting `UserModel` (must be authenticated -- callers
+      pass `self.get_user()`, which never returns `None`: it raises
+      `InvalidUsage` instead)
     :return: the query, filtered by owner if required
     """
-    if user is None:
-        return query
     user_access = int(current_app.config["USER_ACCESS_ALL_OBJECTS"])
     if (
         not user.is_admin()

--- a/cornflow-server/cornflow/endpoints/raw_json.py
+++ b/cornflow-server/cornflow/endpoints/raw_json.py
@@ -1,0 +1,66 @@
+"""
+Helper for building HTTP responses that splice already-serialized JSON
+text directly into the response body, skipping the decode-into-Python /
+re-encode-to-JSON round trip for columns that are returned verbatim.
+
+Only safe for fields that are never transformed before being returned:
+the DB is trusted to hold valid JSON in the column, and that text is
+passed straight through to the client unchanged.
+"""
+
+import json
+
+from flask import Response, current_app
+
+from cornflow.shared.const import USER_ACCESS_ALL_OBJECTS_NO
+
+
+def restrict_to_owner(query, model, user):
+    """
+    Mirrors the ownership filter in `BaseDataModel.get_one_object`: a
+    non-admin, non-service user only sees their own rows, unless the
+    deployment has `USER_ACCESS_ALL_OBJECTS` enabled. Endpoints querying
+    the ORM entity directly get this for free; endpoints building their
+    own Core-style query (to skip JSON decode on huge columns) need to
+    apply it explicitly, since they bypass `get_one_object` entirely.
+
+    :param query: a SQLAlchemy query/session.query(...) object
+    :param model: the model class being queried (must have `user_id`)
+    :param user: the requesting `UserModel`, or None
+    :return: the query, filtered by owner if required
+    """
+    if user is None:
+        return query
+    user_access = int(current_app.config["USER_ACCESS_ALL_OBJECTS"])
+    if (
+        not user.is_admin()
+        and not user.is_service_user()
+        and user_access == USER_ACCESS_ALL_OBJECTS_NO
+    ):
+        query = query.filter(model.user_id == user.id)
+    return query
+
+
+def raw_json_object_response(fields, status=200):
+    """
+    Build a `flask.Response` whose body is a single JSON object.
+
+    :param fields: ordered list of (key, value, is_raw) tuples.
+      When `is_raw` is True, `value` must already be a valid JSON string
+      (typically fetched via `sqlalchemy.cast(col, db.Text)` to skip the
+      column's normal JSON decode), or None (encoded as the JSON literal
+      ``null``). When `is_raw` is False, `value` is encoded normally with
+      `json.dumps`.
+    :param int status: HTTP status code for the response
+    :return: a `flask.Response` with ``Content-Type: application/json``
+    :rtype: `flask.Response`
+    """
+    parts = []
+    for key, value, is_raw in fields:
+        if is_raw:
+            encoded_value = "null" if value is None else value
+        else:
+            encoded_value = json.dumps(value)
+        parts.append(f"{json.dumps(key)}: {encoded_value}")
+    body = "{" + ", ".join(parts) + "}"
+    return Response(body, mimetype="application/json", status=status)

--- a/cornflow-server/cornflow/tests/load/_deprecated_routes.py
+++ b/cornflow-server/cornflow/tests/load/_deprecated_routes.py
@@ -1,0 +1,65 @@
+"""
+Shared helper for the benchmark scripts in this package.
+
+The live app only routes the ``*Raw`` endpoint implementations now (see
+``cornflow.endpoints.__init__``) -- the deprecated Original/Fast classes
+are no longer wired up there. To let the benchmark scripts still compare
+all variants side by side, this module registers the deprecated classes
+on extra, benchmark-only URLs directly on the test app, and grants them
+the same GET permission the old routes used to carry (cornflow's
+`@authenticate` decorator checks a DB-backed ``ViewModel`` /
+``PermissionViewRoleModel`` pair per request, keyed by the exact
+``url_rule`` string -- it isn't satisfied by the resource's static
+``ROLES_WITH_ACCESS`` list alone).
+"""
+
+from cornflow.models import PermissionViewRoleModel, ViewModel
+from cornflow.shared.const import GET_ACTION
+
+
+def register_deprecated_route(app, url_rule, endpoint_name, view_class, roles):
+    """
+    Add a benchmark-only Flask route for a deprecated (unrouted) resource
+    class, and grant it GET permission for `roles`.
+
+    Must be called after `TestCase._pre_setup()` (so `app` exists) but
+    before the first request is dispatched (Flask locks `add_url_rule`
+    after that) -- i.e. before `TestCase.setUp()`.
+
+    :param app: the Flask app (`case.app` after `_pre_setup()`)
+    :param str url_rule: the URL pattern to register, e.g.
+      ``"/dag/<string:idx>/_benchmark_original/"``
+    :param str endpoint_name: a unique Flask endpoint name for this route
+    :param view_class: the deprecated `flask_restful.Resource` subclass
+    :param list roles: role IDs to grant GET access to (typically the
+      deprecated class's own `ROLES_WITH_ACCESS`)
+    """
+    app.add_url_rule(url_rule, view_func=view_class.as_view(endpoint_name))
+    return url_rule, endpoint_name, roles
+
+
+def grant_get_permission(url_rule, endpoint_name, roles):
+    """
+    Insert the `ViewModel` / `PermissionViewRoleModel` rows needed for
+    `@authenticate` to allow GET requests to `url_rule` for `roles`.
+
+    Must be called after `TestCase.setUp()` (so the `api_view`/`roles`/
+    `actions` tables exist).
+    """
+    view = ViewModel.get_one_by_name(endpoint_name)
+    if view is None:
+        view = ViewModel(
+            dict(
+                name=endpoint_name,
+                url_rule=url_rule,
+                description=f"Benchmark-only route for {endpoint_name}",
+            )
+        )
+        view.save()
+    for role in roles:
+        if not PermissionViewRoleModel.get_permission(
+            role_id=role, api_view_id=view.id, action_id=GET_ACTION
+        ):
+            PermissionViewRoleModel(
+                dict(action_id=GET_ACTION, api_view_id=view.id, role_id=role)
+            ).save()

--- a/cornflow-server/cornflow/tests/load/benchmark_case_data_endpoint.py
+++ b/cornflow-server/cornflow/tests/load/benchmark_case_data_endpoint.py
@@ -1,0 +1,114 @@
+"""
+Benchmark comparing ``CaseDataEndpoint`` (full ORM object fetch,
+DEPRECATED, no longer routed in the live app) against
+``CaseDataEndpointRaw`` (raw-JSON-passthrough, the live implementation
+routed at ``/case/<idx>/data/``) when both ``case.data`` and
+``case.solution`` are very large.
+
+Unlike the DAG/instance/execution raw endpoints, this one still decodes
+``solution`` once (to compute the ``indicators`` field), so it is expected
+to show a smaller speedup than those -- it only skips the decode+encode
+round trip for ``data``/``checks``/``solution_checks``/``kpis``, and only
+the encode half for ``solution``.
+
+This is a standalone script, not a pytest test (the filename does not match
+``test_*.py`` so it is never collected). It uses the Flask test client, so
+timings reflect server-side (ORM + JSON (de)serialization) overhead rather
+than network latency.
+
+Run from ``cornflow-server``:
+
+    python -m cornflow.tests.load.benchmark_case_data_endpoint
+"""
+
+import statistics
+
+from cornflow.endpoints.case import CaseDataEndpoint
+from cornflow.models import CaseModel
+from cornflow.shared import db
+from cornflow.tests.custom_test_case import CustomTestCase
+from cornflow.tests.const import CASE_URL
+from cornflow.tests.load.benchmark_dag_endpoint import (
+    _build_large_payload,
+    _report,
+    _time_requests,
+)
+from cornflow.tests.load._deprecated_routes import (
+    grant_get_permission,
+    register_deprecated_route,
+)
+
+# Target size (bytes) of EACH of the case.data / case.solution JSON blobs.
+TARGET_BYTES = 100 * 1024 * 1024
+
+# Number of timed GET requests per endpoint.
+NUM_REQUESTS = 20
+
+VARIANTS = [
+    ("original", "_benchmark_original/"),
+    ("raw", "data/"),
+]
+
+DEPRECATED_ROUTE = (
+    "/case/<int:idx>/_benchmark_original/",
+    "case_data_benchmark_original",
+    CaseDataEndpoint,
+)
+
+
+def run():
+    case_test = CustomTestCase()
+    case_test._pre_setup()
+    url_rule, endpoint_name, view_class = DEPRECATED_ROUTE
+    register_deprecated_route(
+        case_test.app, url_rule, endpoint_name, view_class, view_class.ROLES_WITH_ACCESS
+    )
+    case_test.setUp()
+    grant_get_permission(url_rule, endpoint_name, view_class.ROLES_WITH_ACCESS)
+    try:
+        print(
+            f"Building case data/solution payloads of ~{TARGET_BYTES / (1024 * 1024):.0f} MB each ..."
+        )
+        case_data = _build_large_payload(TARGET_BYTES)
+        case_solution = _build_large_payload(TARGET_BYTES)
+        case_solution["indicators"] = {"cost": 123.4, "time": 5.6}
+
+        print("Saving case row ...")
+        case = CaseModel(
+            dict(
+                user_id=case_test.user.id,
+                name="benchmark-case",
+                description="benchmark fixture",
+                data=case_data,
+                checks={"check_1": []},
+                solution=case_solution,
+                solution_checks={"solution_check_1": []},
+                kpis={"kpi_1": 42},
+                schema=None,
+            )
+        )
+        case.save()
+
+        headers = case_test.get_header_with_auth(case_test.token)
+
+        results = {}
+        for name, url_suffix in VARIANTS:
+            print(f"\nTiming {NUM_REQUESTS} requests against the {name} endpoint ...")
+            url = f"{CASE_URL}{case.id}/{url_suffix}"
+            results[name] = _time_requests(case_test.client, url, headers, NUM_REQUESTS)
+
+        for name, _ in VARIANTS:
+            _report(name, results[name])
+
+        baseline = statistics.mean(results["original"])
+        print("\nSpeedup vs original (mean):")
+        for name, _ in VARIANTS[1:]:
+            speedup = baseline / statistics.mean(results[name])
+            print(f"  {name}: {speedup:.2f}x")
+    finally:
+        case_test.tearDown()
+        case_test._post_teardown()
+
+
+if __name__ == "__main__":
+    run()

--- a/cornflow-server/cornflow/tests/load/benchmark_dag_endpoint.py
+++ b/cornflow-server/cornflow/tests/load/benchmark_dag_endpoint.py
@@ -1,13 +1,10 @@
 """
-Benchmark comparing three implementations of the same GET endpoint
+Benchmark comparing two implementations of the same GET endpoint
 (execution + instance ``data``, plus ``config``) when those JSON fields
 are very large:
 
 - DAGDetailEndpoint: two full ORM object fetches. DEPRECATED, no longer
   routed in the live app -- registered here on a benchmark-only path.
-- DAGDetailEndpointFast: one column-pruned JOIN query, still decoding the
-  JSON columns into Python. DEPRECATED, no longer routed in the live app --
-  registered here on a benchmark-only path.
 - DAGDetailEndpointRaw: one column-pruned JOIN query that casts the JSON
   columns to text, skipping decode entirely, and splices the raw JSON text
   straight into a hand-built response body. This is the live implementation,
@@ -27,7 +24,7 @@ import json
 import statistics
 import time
 
-from cornflow.endpoints.dag import DAGDetailEndpoint, DAGDetailEndpointFast
+from cornflow.endpoints.dag import DAGDetailEndpoint
 from cornflow.models import ExecutionModel, InstanceModel
 from cornflow.shared import db
 from cornflow.tests.base_test_execution import TestExecutionsDetailEndpointMock
@@ -47,46 +44,37 @@ NUM_REQUESTS = 20
 
 VARIANTS = [
     ("original", "_benchmark_original/"),
-    ("fast", "_benchmark_fast/"),
     ("raw", ""),
 ]
 
-
-DEPRECATED_ROUTES = [
-    (
-        "/dag/<string:idx>/_benchmark_original/",
-        "dag_benchmark_original",
-        DAGDetailEndpoint,
-    ),
-    (
-        "/dag/<string:idx>/_benchmark_fast/",
-        "dag_benchmark_fast",
-        DAGDetailEndpointFast,
-    ),
-]
+DEPRECATED_ROUTE = (
+    "/dag/<string:idx>/_benchmark_original/",
+    "dag_benchmark_original",
+    DAGDetailEndpoint,
+)
 
 
 def _register_deprecated_routes(app):
     """
     The live app only routes DAGDetailEndpointRaw at /dag/<idx>/ now (see
-    cornflow.endpoints.__init__). Register the deprecated Original/Fast
-    implementations on separate, benchmark-only paths so this script can
-    still compare all three. Must run before `case.setUp()` (Flask locks
-    `add_url_rule` after the first request).
+    cornflow.endpoints.__init__). Register the deprecated Original
+    implementation on a separate, benchmark-only path so this script can
+    still compare it against the live one. Must run before `case.setUp()`
+    (Flask locks `add_url_rule` after the first request).
     """
-    for url_rule, endpoint_name, view_class in DEPRECATED_ROUTES:
-        register_deprecated_route(
-            app, url_rule, endpoint_name, view_class, view_class.ROLES_WITH_ACCESS
-        )
+    url_rule, endpoint_name, view_class = DEPRECATED_ROUTE
+    register_deprecated_route(
+        app, url_rule, endpoint_name, view_class, view_class.ROLES_WITH_ACCESS
+    )
 
 
 def _grant_deprecated_permissions():
     """
-    Grant GET permission for the benchmark-only routes. Must run after
+    Grant GET permission for the benchmark-only route. Must run after
     `case.setUp()` (needs the `api_view`/`roles`/`actions` tables).
     """
-    for url_rule, endpoint_name, view_class in DEPRECATED_ROUTES:
-        grant_get_permission(url_rule, endpoint_name, view_class.ROLES_WITH_ACCESS)
+    url_rule, endpoint_name, view_class = DEPRECATED_ROUTE
+    grant_get_permission(url_rule, endpoint_name, view_class.ROLES_WITH_ACCESS)
 
 
 def _build_large_payload(target_bytes):

--- a/cornflow-server/cornflow/tests/load/benchmark_dag_endpoint.py
+++ b/cornflow-server/cornflow/tests/load/benchmark_dag_endpoint.py
@@ -1,0 +1,194 @@
+"""
+Benchmark comparing three implementations of the same GET endpoint
+(execution + instance ``data``, plus ``config``) when those JSON fields
+are very large:
+
+- DAGDetailEndpoint: two full ORM object fetches. DEPRECATED, no longer
+  routed in the live app -- registered here on a benchmark-only path.
+- DAGDetailEndpointFast: one column-pruned JOIN query, still decoding the
+  JSON columns into Python. DEPRECATED, no longer routed in the live app --
+  registered here on a benchmark-only path.
+- DAGDetailEndpointRaw: one column-pruned JOIN query that casts the JSON
+  columns to text, skipping decode entirely, and splices the raw JSON text
+  straight into a hand-built response body. This is the live implementation,
+  routed at ``/dag/<idx>/``.
+
+This is a standalone script, not a pytest test (the filename does not match
+``test_*.py`` so it is never collected). It uses the Flask test client, so
+timings reflect server-side (ORM + JSON (de)serialization) overhead rather
+than network latency.
+
+Run from ``cornflow-server``:
+
+    python -m cornflow.tests.load.benchmark_dag_endpoint
+"""
+
+import json
+import statistics
+import time
+
+from cornflow.endpoints.dag import DAGDetailEndpoint, DAGDetailEndpointFast
+from cornflow.models import ExecutionModel, InstanceModel
+from cornflow.shared import db
+from cornflow.tests.base_test_execution import TestExecutionsDetailEndpointMock
+from cornflow.tests.const import DAG_URL
+from cornflow.tests.load._deprecated_routes import (
+    grant_get_permission,
+    register_deprecated_route,
+)
+
+# Target size (bytes) of EACH of the instance.data / execution.data JSON blobs.
+TARGET_BYTES = 100 * 1024 * 1024
+
+# Number of timed GET requests per endpoint. Each request round-trips the
+# full ~TARGET_BYTES JSON payload through Flask's JSON encoder, so keep this
+# modest unless you're prepared to wait a while.
+NUM_REQUESTS = 20
+
+VARIANTS = [
+    ("original", "_benchmark_original/"),
+    ("fast", "_benchmark_fast/"),
+    ("raw", ""),
+]
+
+
+DEPRECATED_ROUTES = [
+    (
+        "/dag/<string:idx>/_benchmark_original/",
+        "dag_benchmark_original",
+        DAGDetailEndpoint,
+    ),
+    (
+        "/dag/<string:idx>/_benchmark_fast/",
+        "dag_benchmark_fast",
+        DAGDetailEndpointFast,
+    ),
+]
+
+
+def _register_deprecated_routes(app):
+    """
+    The live app only routes DAGDetailEndpointRaw at /dag/<idx>/ now (see
+    cornflow.endpoints.__init__). Register the deprecated Original/Fast
+    implementations on separate, benchmark-only paths so this script can
+    still compare all three. Must run before `case.setUp()` (Flask locks
+    `add_url_rule` after the first request).
+    """
+    for url_rule, endpoint_name, view_class in DEPRECATED_ROUTES:
+        register_deprecated_route(
+            app, url_rule, endpoint_name, view_class, view_class.ROLES_WITH_ACCESS
+        )
+
+
+def _grant_deprecated_permissions():
+    """
+    Grant GET permission for the benchmark-only routes. Must run after
+    `case.setUp()` (needs the `api_view`/`roles`/`actions` tables).
+    """
+    for url_rule, endpoint_name, view_class in DEPRECATED_ROUTES:
+        grant_get_permission(url_rule, endpoint_name, view_class.ROLES_WITH_ACCESS)
+
+
+def _build_large_payload(target_bytes):
+    """Build a JSON-serializable dict that is at least `target_bytes` when dumped."""
+    unit = {"idx": 0, "values": list(range(50)), "text": "x" * 500}
+    unit_size = len(json.dumps(unit))
+    count = max(1, target_bytes // unit_size)
+    return {"rows": [{**unit, "idx": i} for i in range(count)]}
+
+
+def _time_requests(client, url, headers, n):
+    """
+    Times `n` GETs against `url`. `db.session.remove()` is called before
+    each request to force a fresh session, mirroring how a real deployment
+    tears the session down at the end of every request (via Flask-SQLAlchemy's
+    teardown_appcontext). Without this, the flask_testing harness keeps one
+    long-lived session across all requests in a run, and the ORM path
+    silently benefits from SQLAlchemy's identity-map caching of previously
+    loaded rows -- an artifact that would not happen in production and that
+    massively (and unfairly) skews a same-row, repeated-GET benchmark.
+    """
+    durations = []
+    for i in range(n):
+        db.session.remove()
+        start = time.perf_counter()
+        response = client.get(url, headers=headers, follow_redirects=True)
+        durations.append(time.perf_counter() - start)
+        if response.status_code != 200:
+            raise RuntimeError(f"GET {url} returned {response.status_code}")
+        print(f"    request {i + 1}/{n}: {durations[-1]:.3f}s")
+    return durations
+
+
+def _report(name, durations):
+    print(f"\n{name}:")
+    print(f"  min:    {min(durations):.3f}s")
+    print(f"  mean:   {statistics.mean(durations):.3f}s")
+    print(f"  median: {statistics.median(durations):.3f}s")
+    if len(durations) > 1:
+        print(f"  stdev:  {statistics.stdev(durations):.3f}s")
+    print(f"  max:    {max(durations):.3f}s")
+
+
+def run():
+    case = TestExecutionsDetailEndpointMock()
+    case._pre_setup()
+    _register_deprecated_routes(case.app)
+    case.setUp()
+    _grant_deprecated_permissions()
+    try:
+        print(
+            f"Building instance/execution payloads of ~{TARGET_BYTES / (1024 * 1024):.0f} MB each ..."
+        )
+        instance_data = _build_large_payload(TARGET_BYTES)
+        execution_data = _build_large_payload(TARGET_BYTES)
+
+        print("Saving instance and execution rows ...")
+        instance = InstanceModel(
+            dict(
+                user_id=case.user.id,
+                name="benchmark-instance",
+                description="benchmark fixture",
+                data=instance_data,
+                schema=None,
+            )
+        )
+        instance.save()
+
+        execution = ExecutionModel(
+            dict(
+                user_id=case.user.id,
+                instance_id=instance.id,
+                name="benchmark-execution",
+                description="benchmark fixture",
+                data=execution_data,
+                config={"solver": "cbc"},
+                schema=None,
+            )
+        )
+        execution.save()
+
+        token = case.create_service_user()
+        headers = case.get_header_with_auth(token)
+
+        results = {}
+        for name, url_suffix in VARIANTS:
+            print(f"\nTiming {NUM_REQUESTS} requests against the {name} endpoint ...")
+            url = f"{DAG_URL}{execution.id}/{url_suffix}"
+            results[name] = _time_requests(case.client, url, headers, NUM_REQUESTS)
+
+        for name, _ in VARIANTS:
+            _report(name, results[name])
+
+        baseline = statistics.mean(results["original"])
+        print("\nSpeedup vs original (mean):")
+        for name, _ in VARIANTS[1:]:
+            speedup = baseline / statistics.mean(results[name])
+            print(f"  {name}: {speedup:.2f}x")
+    finally:
+        case.tearDown()
+        case._post_teardown()
+
+
+if __name__ == "__main__":
+    run()

--- a/cornflow-server/cornflow/tests/load/benchmark_execution_data_endpoint.py
+++ b/cornflow-server/cornflow/tests/load/benchmark_execution_data_endpoint.py
@@ -1,0 +1,115 @@
+"""
+Benchmark comparing ``ExecutionDataEndpoint`` (full ORM object fetch,
+DEPRECATED, no longer routed in the live app) against
+``ExecutionDataEndpointRaw`` (raw-JSON-passthrough for ``data``/``checks``/
+``kpis``, the live implementation routed at ``/execution/<idx>/data/``)
+when ``execution.data`` is very large.
+
+This is a standalone script, not a pytest test (the filename does not match
+``test_*.py`` so it is never collected). It uses the Flask test client, so
+timings reflect server-side (ORM + JSON (de)serialization) overhead rather
+than network latency.
+
+Run from ``cornflow-server``:
+
+    python -m cornflow.tests.load.benchmark_execution_data_endpoint
+"""
+
+import statistics
+
+from cornflow.endpoints.execution import ExecutionDataEndpoint
+from cornflow.models import ExecutionModel, InstanceModel
+from cornflow.shared import db
+from cornflow.tests.custom_test_case import CustomTestCase
+from cornflow.tests.const import EXECUTION_URL
+from cornflow.tests.load.benchmark_dag_endpoint import (
+    _build_large_payload,
+    _report,
+    _time_requests,
+)
+from cornflow.tests.load._deprecated_routes import (
+    grant_get_permission,
+    register_deprecated_route,
+)
+
+# Target size (bytes) of the execution.data JSON blob.
+TARGET_BYTES = 100 * 1024 * 1024
+
+# Number of timed GET requests per endpoint.
+NUM_REQUESTS = 20
+
+VARIANTS = [
+    ("original", "_benchmark_original/"),
+    ("raw", "data/"),
+]
+
+DEPRECATED_ROUTE = (
+    "/execution/<string:idx>/_benchmark_original/",
+    "execution_data_benchmark_original",
+    ExecutionDataEndpoint,
+)
+
+
+def run():
+    case = CustomTestCase()
+    case._pre_setup()
+    url_rule, endpoint_name, view_class = DEPRECATED_ROUTE
+    register_deprecated_route(
+        case.app, url_rule, endpoint_name, view_class, view_class.ROLES_WITH_ACCESS
+    )
+    case.setUp()
+    grant_get_permission(url_rule, endpoint_name, view_class.ROLES_WITH_ACCESS)
+    try:
+        print(f"Building execution payload of ~{TARGET_BYTES / (1024 * 1024):.0f} MB ...")
+        execution_data = _build_large_payload(TARGET_BYTES)
+
+        print("Saving instance and execution rows ...")
+        instance = InstanceModel(
+            dict(
+                user_id=case.user.id,
+                name="benchmark-instance",
+                description="benchmark fixture",
+                data={"small": True},
+                schema=None,
+            )
+        )
+        instance.save()
+
+        execution = ExecutionModel(
+            dict(
+                user_id=case.user.id,
+                instance_id=instance.id,
+                name="benchmark-execution",
+                description="benchmark fixture",
+                data=execution_data,
+                checks={"check_1": []},
+                kpis={"kpi_1": 42},
+                config={"solver": "cbc"},
+                schema=None,
+            )
+        )
+        execution.save()
+
+        headers = case.get_header_with_auth(case.token)
+
+        results = {}
+        for name, url_suffix in VARIANTS:
+            print(f"\nTiming {NUM_REQUESTS} requests against the {name} endpoint ...")
+            url = f"{EXECUTION_URL}{execution.id}/{url_suffix}"
+            results[name] = _time_requests(case.client, url, headers, NUM_REQUESTS)
+
+        for name, _ in VARIANTS:
+            _report(name, results[name])
+
+        baseline = statistics.mean(results["original"])
+        print("\nSpeedup vs original (mean):")
+        for name, _ in VARIANTS[1:]:
+            speedup = baseline / statistics.mean(results[name])
+            print(f"  {name}: {speedup:.2f}x")
+    finally:
+        case.tearDown()
+        case._post_teardown()
+
+
+if __name__ == "__main__":
+    run()

--- a/cornflow-server/cornflow/tests/load/benchmark_instance_data_endpoint.py
+++ b/cornflow-server/cornflow/tests/load/benchmark_instance_data_endpoint.py
@@ -1,0 +1,99 @@
+"""
+Benchmark comparing ``InstanceDataEndpoint`` (full ORM object fetch,
+DEPRECATED, no longer routed in the live app) against
+``InstanceDataEndpointRaw`` (raw-JSON-passthrough, the live implementation
+routed at ``/instance/<idx>/data/``) when ``instance.data`` is very large.
+
+This is a standalone script, not a pytest test (the filename does not match
+``test_*.py`` so it is never collected). It uses the Flask test client, so
+timings reflect server-side (ORM + JSON (de)serialization) overhead rather
+than network latency.
+
+Run from ``cornflow-server``:
+
+    python -m cornflow.tests.load.benchmark_instance_data_endpoint
+"""
+
+import statistics
+
+from cornflow.endpoints.instance import InstanceDataEndpoint
+from cornflow.models import InstanceModel
+from cornflow.shared import db
+from cornflow.tests.custom_test_case import CustomTestCase
+from cornflow.tests.const import INSTANCE_URL
+from cornflow.tests.load.benchmark_dag_endpoint import (
+    _build_large_payload,
+    _report,
+    _time_requests,
+)
+from cornflow.tests.load._deprecated_routes import (
+    grant_get_permission,
+    register_deprecated_route,
+)
+
+# Target size (bytes) of the instance.data JSON blob.
+TARGET_BYTES = 100 * 1024 * 1024
+
+# Number of timed GET requests per endpoint.
+NUM_REQUESTS = 20
+
+VARIANTS = [
+    ("original", "_benchmark_original/"),
+    ("raw", "data/"),
+]
+
+DEPRECATED_ROUTE = (
+    "/instance/<string:idx>/_benchmark_original/",
+    "instance_data_benchmark_original",
+    InstanceDataEndpoint,
+)
+
+
+def run():
+    case = CustomTestCase()
+    case._pre_setup()
+    url_rule, endpoint_name, view_class = DEPRECATED_ROUTE
+    register_deprecated_route(
+        case.app, url_rule, endpoint_name, view_class, view_class.ROLES_WITH_ACCESS
+    )
+    case.setUp()
+    grant_get_permission(url_rule, endpoint_name, view_class.ROLES_WITH_ACCESS)
+    try:
+        print(f"Building instance payload of ~{TARGET_BYTES / (1024 * 1024):.0f} MB ...")
+        instance_data = _build_large_payload(TARGET_BYTES)
+
+        print("Saving instance row ...")
+        instance = InstanceModel(
+            dict(
+                user_id=case.user.id,
+                name="benchmark-instance",
+                description="benchmark fixture",
+                data=instance_data,
+                schema=None,
+            )
+        )
+        instance.save()
+
+        headers = case.get_header_with_auth(case.token)
+
+        results = {}
+        for name, url_suffix in VARIANTS:
+            print(f"\nTiming {NUM_REQUESTS} requests against the {name} endpoint ...")
+            url = f"{INSTANCE_URL}{instance.id}/{url_suffix}"
+            results[name] = _time_requests(case.client, url, headers, NUM_REQUESTS)
+
+        for name, _ in VARIANTS:
+            _report(name, results[name])
+
+        baseline = statistics.mean(results["original"])
+        print("\nSpeedup vs original (mean):")
+        for name, _ in VARIANTS[1:]:
+            speedup = baseline / statistics.mean(results[name])
+            print(f"  {name}: {speedup:.2f}x")
+    finally:
+        case.tearDown()
+        case._post_teardown()
+
+
+if __name__ == "__main__":
+    run()

--- a/cornflow-server/cornflow/tests/unit/test_cases.py
+++ b/cornflow-server/cornflow/tests/unit/test_cases.py
@@ -959,6 +959,13 @@ class TestCaseDataEndpoint(CustomTestCase):
             "data",
         ]
 
+    def _data_url(self, idx):
+        """
+        URL used by the tests below. Overridden by subclasses that
+        exercise an alternate implementation of the same endpoint.
+        """
+        return self.url + str(idx) + "/data/"
+
     def test_get_data(self):
         """
         Test retrieving case data.
@@ -988,7 +995,7 @@ class TestCaseDataEndpoint(CustomTestCase):
             "kpis",
         ]
         self.get_one_row(
-            self.url + str(self.payload["id"]) + "/data/",
+            self._data_url(self.payload["id"]),
             self.payload,
             keys_to_check=keys_to_check,
         )
@@ -1000,7 +1007,7 @@ class TestCaseDataEndpoint(CustomTestCase):
         Verifies proper error handling for non-existent cases.
         """
         self.get_one_row(
-            self.url + str(500) + "/data/",
+            self._data_url(500),
             {},
             expected_status=404,
             check_payload=False,
@@ -1020,7 +1027,7 @@ class TestCaseDataEndpoint(CustomTestCase):
         headers["Accept-Encoding"] = "gzip"
 
         response = self.client.get(
-            self.url + str(self.payload["id"]) + "/data/", headers=headers
+            self._data_url(self.payload["id"]), headers=headers
         )
         self.assertEqual(response.headers["Content-Encoding"], "gzip")
         raw = zlib.decompress(response.data, 16 + zlib.MAX_WBITS).decode("utf-8")

--- a/cornflow-server/cornflow/tests/unit/test_dags.py
+++ b/cornflow-server/cornflow/tests/unit/test_dags.py
@@ -280,65 +280,6 @@ class TestDagDetailEndpoint(TestExecutionsDetailEndpointMock):
         )
 
 
-class TestDagDetailEndpointFastDeprecated(TestExecutionsDetailEndpointMock):
-    """
-    DAGDetailEndpointFast is DEPRECATED and no longer routed in the live
-    app (superseded by DAGDetailEndpointRaw) -- see its docstring. It's
-    kept only so the benchmark scripts in cornflow.tests.load can still
-    compare it against the other variants. This test wires it onto an
-    ad-hoc route the same way those scripts do, so it stays under
-    regression coverage instead of silently bit-rotting.
-    """
-
-    URL_RULE = "/dag/<string:idx>/_test_fast/"
-    ENDPOINT_NAME = "dag_fast_test"
-
-    def setUp(self):
-        from cornflow.endpoints.dag import DAGDetailEndpointFast
-        from cornflow.tests.load._deprecated_routes import (
-            grant_get_permission,
-            register_deprecated_route,
-        )
-
-        # Must run before super().setUp() (Flask locks add_url_rule after
-        # the first request, which super().setUp() triggers via signup/login).
-        register_deprecated_route(
-            self.app,
-            self.URL_RULE,
-            self.ENDPOINT_NAME,
-            DAGDetailEndpointFast,
-            DAGDetailEndpointFast.ROLES_WITH_ACCESS,
-        )
-        super().setUp()
-        # Must run after super().setUp() (needs the api_view/roles/actions tables).
-        grant_get_permission(
-            self.URL_RULE, self.ENDPOINT_NAME, DAGDetailEndpointFast.ROLES_WITH_ACCESS
-        )
-
-    def test_get_dag_fast(self):
-        idx = self.create_new_row(EXECUTION_URL_NORUN, self.model, self.payload)
-        token = self.create_service_user()
-        keys_to_check = ["id", "data", "solution_data", "config"]
-        self.get_one_row(
-            url=f"/dag/{idx}/_test_fast/",
-            token=token,
-            check_payload=False,
-            payload=self.payload,
-            keys_to_check=keys_to_check,
-        )
-
-    def test_get_dag_fast_not_found(self):
-        token = self.create_service_user()
-        self.get_one_row(
-            url="/dag/this_execution_does_not_exist/_test_fast/",
-            token=token,
-            check_payload=False,
-            payload={},
-            expected_status=404,
-            keys_to_check=["error"],
-        )
-
-
 class TestDeployedDAG(TestCase):
     """
     Test suite for deployed DAG functionality.

--- a/cornflow-server/cornflow/tests/unit/test_dags.py
+++ b/cornflow-server/cornflow/tests/unit/test_dags.py
@@ -262,6 +262,82 @@ class TestDagDetailEndpoint(TestExecutionsDetailEndpointMock):
             keys_to_check=["error"],
         )
 
+    def test_get_dag_execution_not_found(self):
+        """
+        Test retrieving a DAG for an execution id that does not exist at
+        all, as an authorized (service) user -- distinct from
+        test_get_no_dag, which checks the permission-denied (403) path for
+        an unauthorized user. This exercises the "not found" (404) branch.
+        """
+        token = self.create_service_user()
+        self.get_one_row(
+            url=self._dag_get_url("this_execution_does_not_exist"),
+            token=token,
+            check_payload=False,
+            payload={},
+            expected_status=404,
+            keys_to_check=["error"],
+        )
+
+
+class TestDagDetailEndpointFastDeprecated(TestExecutionsDetailEndpointMock):
+    """
+    DAGDetailEndpointFast is DEPRECATED and no longer routed in the live
+    app (superseded by DAGDetailEndpointRaw) -- see its docstring. It's
+    kept only so the benchmark scripts in cornflow.tests.load can still
+    compare it against the other variants. This test wires it onto an
+    ad-hoc route the same way those scripts do, so it stays under
+    regression coverage instead of silently bit-rotting.
+    """
+
+    URL_RULE = "/dag/<string:idx>/_test_fast/"
+    ENDPOINT_NAME = "dag_fast_test"
+
+    def setUp(self):
+        from cornflow.endpoints.dag import DAGDetailEndpointFast
+        from cornflow.tests.load._deprecated_routes import (
+            grant_get_permission,
+            register_deprecated_route,
+        )
+
+        # Must run before super().setUp() (Flask locks add_url_rule after
+        # the first request, which super().setUp() triggers via signup/login).
+        register_deprecated_route(
+            self.app,
+            self.URL_RULE,
+            self.ENDPOINT_NAME,
+            DAGDetailEndpointFast,
+            DAGDetailEndpointFast.ROLES_WITH_ACCESS,
+        )
+        super().setUp()
+        # Must run after super().setUp() (needs the api_view/roles/actions tables).
+        grant_get_permission(
+            self.URL_RULE, self.ENDPOINT_NAME, DAGDetailEndpointFast.ROLES_WITH_ACCESS
+        )
+
+    def test_get_dag_fast(self):
+        idx = self.create_new_row(EXECUTION_URL_NORUN, self.model, self.payload)
+        token = self.create_service_user()
+        keys_to_check = ["id", "data", "solution_data", "config"]
+        self.get_one_row(
+            url=f"/dag/{idx}/_test_fast/",
+            token=token,
+            check_payload=False,
+            payload=self.payload,
+            keys_to_check=keys_to_check,
+        )
+
+    def test_get_dag_fast_not_found(self):
+        token = self.create_service_user()
+        self.get_one_row(
+            url="/dag/this_execution_does_not_exist/_test_fast/",
+            token=token,
+            check_payload=False,
+            payload={},
+            expected_status=404,
+            keys_to_check=["error"],
+        )
+
 
 class TestDeployedDAG(TestCase):
     """

--- a/cornflow-server/cornflow/tests/unit/test_dags.py
+++ b/cornflow-server/cornflow/tests/unit/test_dags.py
@@ -141,6 +141,13 @@ class TestDagDetailEndpoint(TestExecutionsDetailEndpointMock):
     - Error handling for unauthorized access
     """
 
+    def _dag_get_url(self, idx):
+        """
+        URL used by test_get_dag/test_get_no_dag. Overridden by subclasses
+        that exercise an alternate implementation of the same endpoint.
+        """
+        return f"{DAG_URL}{idx}/"
+
     def test_put_dag(self):
         """
         Test updating a DAG.
@@ -209,7 +216,7 @@ class TestDagDetailEndpoint(TestExecutionsDetailEndpointMock):
         token = self.create_service_user()
         keys_to_check = ["id", "data", "solution_data", "config"]
         data = self.get_one_row(
-            url=DAG_URL + idx + "/",
+            url=self._dag_get_url(idx),
             token=token,
             check_payload=False,
             payload=self.payload,
@@ -247,7 +254,7 @@ class TestDagDetailEndpoint(TestExecutionsDetailEndpointMock):
         """
         idx = self.create_new_row(EXECUTION_URL_NORUN, self.model, self.payload)
         data = self.get_one_row(
-            url=DAG_URL + idx + "/",
+            url=self._dag_get_url(idx),
             token=self.token,
             check_payload=False,
             payload=self.payload,

--- a/cornflow-server/cornflow/tests/unit/test_executions.py
+++ b/cornflow-server/cornflow/tests/unit/test_executions.py
@@ -21,6 +21,7 @@ from cornflow.models import ExecutionModel, InstanceModel
 from cornflow.shared import db
 from cornflow.shared.const import (
     ADMIN_ROLE,
+    EXEC_STATE_CORRECT,
     EXECUTION_FILES_STATUS_DELETED,
     EXECUTION_FILES_STATUS_ERROR,
     EXECUTION_FILES_STATUS_NOT_GENERATED,
@@ -30,12 +31,15 @@ from cornflow.shared.const import (
     PLANNER_ROLE,
     VIEWER_ROLE,
 )
+from cornflow.tests.base_test_execution import TestExecutionsDetailEndpointMock
 from cornflow.tests.const import (
+    CASE_PATH,
     DAG_URL,
     EXECUTION_FILES_CLEANUP_URL,
     EXECUTION_FILES_URL,
     EXECUTION_PATH,
     EXECUTION_SOLUTION_PATH,
+    EXECUTION_URL,
     EXECUTION_URL_NORUN,
     INSTANCE_PATH,
     INSTANCE_URL,
@@ -654,3 +658,62 @@ class TestExecutionListDataLoading(CustomTestCase):
                     item,
                     f"Required field '{field}' is missing from the execution list response.",
                 )
+
+
+class TestExecutionDataEndpoint(TestExecutionsDetailEndpointMock):
+    """
+    Confirms `/execution/<idx>/data/` -- now served by
+    ExecutionDataEndpointRaw -- returns the expected payload, including
+    the filtered `log` field, while skipping decode/re-encode of the
+    (potentially huge) `data`/`checks`/`kpis` columns.
+    """
+
+    def _put_solution(self, idx, token):
+        with open(CASE_PATH) as f:
+            case_payload = json.load(f)
+        log_json = {
+            "status": "feasible",
+            "status_code": 2,
+            "sol_code": 1,
+            "some_other_key": "this should be excluded",
+        }
+        self.update_row(
+            url=f"{DAG_URL}{idx}/",
+            payload_to_check={},
+            change=dict(
+                data=case_payload["data"],
+                checks={"check_1": []},
+                kpis={"kpi_1": 42},
+                state=EXEC_STATE_CORRECT,
+                log_json=log_json,
+            ),
+            token=token,
+            check_payload=False,
+        )
+        return case_payload
+
+    def test_get_data(self):
+        idx = self.create_new_row(EXECUTION_URL_NORUN, self.model, self.payload)
+        token = self.create_service_user()
+        case_payload = self._put_solution(idx, token)
+
+        data = self.client.get(
+            EXECUTION_URL + idx + "/data/",
+            headers=self.get_header_with_auth(token),
+        ).json
+
+        self.assertEqual(data["data"], case_payload["data"])
+        self.assertEqual(data["checks"], {"check_1": []})
+        self.assertEqual(data["kpis"], {"kpi_1": 42})
+        self.assertEqual(
+            data["log"], {"status": "feasible", "status_code": 2, "sol_code": 1}
+        )
+        self.assertNotIn("some_other_key", data["log"])
+        self.assertEqual(data["id"], idx)
+
+    def test_get_no_data(self):
+        response = self.client.get(
+            EXECUTION_URL + "nonexistent" + "/data/",
+            headers=self.get_header_with_auth(self.token),
+        )
+        self.assertEqual(response.status_code, 404)

--- a/cornflow-server/cornflow/tests/unit/test_instances.py
+++ b/cornflow-server/cornflow/tests/unit/test_instances.py
@@ -192,6 +192,13 @@ class TestInstancesDataEndpoint(TestInstancesDetailEndpointBase):
         self.response_items.remove("executions")
         self.items_to_check += ["data", "checks"]
 
+    def _data_url(self, idx):
+        """
+        URL used by the tests below. Overridden by subclasses that
+        exercise an alternate implementation of the same endpoint.
+        """
+        return INSTANCE_URL + idx + "/data/"
+
     def test_get_one_instance(self):
         idx = self.create_new_row(self.url, self.model, self.payload)
         payload = {**self.payload, **dict(id=idx)}
@@ -207,7 +214,7 @@ class TestInstancesDataEndpoint(TestInstancesDetailEndpointBase):
             "created_at",
         ]
         result = self.get_one_row(
-            INSTANCE_URL + idx + "/data/", payload, keys_to_check=keys_to_check
+            self._data_url(idx), payload, keys_to_check=keys_to_check
         )
         dif = self.response_items.symmetric_difference(result.keys())
         self.assertEqual(len(dif), 0)
@@ -219,7 +226,7 @@ class TestInstancesDataEndpoint(TestInstancesDetailEndpointBase):
             "Authorization": f"Bearer {self.token}",
             "Accept-Encoding": "gzip",
         }
-        response = self.client.get(INSTANCE_URL + idx + "/data/", headers=headers)
+        response = self.client.get(self._data_url(idx), headers=headers)
         self.assertEqual(response.headers["Content-Encoding"], "gzip")
         raw = zlib.decompress(response.data, 16 + zlib.MAX_WBITS).decode("utf-8")
         response = json.loads(raw)
@@ -230,7 +237,7 @@ class TestInstancesDataEndpoint(TestInstancesDetailEndpointBase):
         idx = self.create_new_row(self.url, self.model, self.payload)
         token = self.create_service_user()
         payload = {**self.payload, **dict(id=idx)}
-        self.get_one_row(INSTANCE_URL + idx + "/data/", payload, token=token)
+        self.get_one_row(self._data_url(idx), payload, token=token)
 
     def test_get_none_instance_planner_one(self):
         # Test planner users cannot access objects of other users
@@ -238,7 +245,7 @@ class TestInstancesDataEndpoint(TestInstancesDetailEndpointBase):
         token = self.create_planner()
 
         self.get_one_row(
-            INSTANCE_URL + idx + "/data/",
+            self._data_url(idx),
             payload=None,
             expected_status=404,
             check_payload=False,


### PR DESCRIPTION
## Summary

Endpoints that return an execution's/instance's/case's `data` field (and siblings) suffered performance issues when that JSON field is large, because the normal path decodes the stored JSON into Python objects and then re-encodes it back to JSON for the HTTP response — pure wasted CPU for fields that are returned verbatim.

This PR:
- Adds "raw" variants for the four affected endpoints that cast the JSON column to text at the SQL layer (skipping decode) and splice the already-valid JSON text directly into a hand-built response body (skipping re-encode): `DAGDetailEndpointRaw`, `InstanceDataEndpointRaw`, `ExecutionDataEndpointRaw`, `CaseDataEndpointRaw`.
- Routes them in place of the original implementations:
  - `GET /dag/<idx>/`
  - `GET /instance/<idx>/data/`
  - `GET /execution/<idx>/data/`
  - `GET /case/<idx>/data/`
- Keeps the original classes (`DAGDetailEndpoint`, `DAGDetailEndpointFast`, `InstanceDataEndpoint`, `ExecutionDataEndpoint`, `CaseDataEndpoint`) in the codebase, marked **DEPRECATED** and **no longer routed**. They're retained because the `*Raw` classes inherit their non-GET methods (`put`/`patch`/`delete`) from them, and so the benchmark scripts can still exercise them for comparison.
- Adds standalone benchmark scripts (`cornflow/tests/load/`, not collected by pytest) that build ~100MB JSON fixtures and time the deprecated vs. live implementations side by side. They self-register the deprecated classes on benchmark-only routes with the matching DB permission rows, since those routes are no longer part of the live app.

Case is a partial win: `solution` still needs one decode to compute the `indicators` field, so only the re-encode half of its round trip is skipped (the other four big fields — `data`, `checks`, `solution_checks`, `kpis` — skip both).

## Benchmark results (100MB per field, mean of 8 requests, fresh DB session per request)

| Endpoint | Original | Raw | Speedup |
|---|---|---|---|
| `GET /dag/<idx>/` | 4.54s | 0.95s | **4.79x** |
| `GET /instance/<idx>/data/` | 2.31s | 0.58s | **3.98x** |
| `GET /execution/<idx>/data/` | 2.43s | 0.58s | **4.19x** |
| `GET /case/<idx>/data/` | 4.95s | 2.23s | **2.22x** (partial, as expected) |

(The intermediate `DAGDetailEndpointFast` variant, tried first, showed no real improvement over the original at this payload size — see script output — which is why it was superseded by the raw-passthrough approach rather than promoted.)

Reproduce with, e.g.:
```
cd cornflow-server
python -m cornflow.tests.load.benchmark_dag_endpoint
python -m cornflow.tests.load.benchmark_instance_data_endpoint
python -m cornflow.tests.load.benchmark_execution_data_endpoint
python -m cornflow.tests.load.benchmark_case_data_endpoint
```

## Test plan
- [x] Existing test suites for `test_dags.py`, `test_instances.py`, `test_executions.py`, `test_cases.py` reused/adapted against the new routing (URL-override subclassing where a base class already existed) — 123 passed.
- [x] Full `cornflow/tests/unit` suite run both with these changes and against a stashed baseline; diffed the failure lists — identical 75 pre-existing failures in unrelated files (alarms/cli/commands/permissions/roles/schemas/signup) both times, confirming no regression from this change.
- [x] All four benchmark scripts run end-to-end at 100MB, confirming the routing swap and the deprecated-route self-registration work correctly.

Claude-Session: https://claude.ai/code/session_01UKhuvDJNSJUiXyb3zqkjAN