### PR TITLE
Feature/hardening uat fixes

### DIFF
--- a/cornflow-server/cornflow/app.py
+++ b/cornflow-server/cornflow/app.py
@@ -45,6 +45,7 @@ from cornflow.shared.const import (
     AUTH_LDAP,
     AUTH_OID,
     CONDITIONAL_ENDPOINTS,
+    SIGNUP_PLATFORM_ADMIN_ONLY,
     SIGNUP_WITH_AUTH,
     SIGNUP_WITH_NO_AUTH,
 )
@@ -197,7 +198,11 @@ def create_app(env_name="development", dataconn=None):
 
     if auth_type == AUTH_DB:
         signup_activated = int(app.config["SIGNUP_ACTIVATED"])
-        if signup_activated in [SIGNUP_WITH_AUTH, SIGNUP_WITH_NO_AUTH]:
+        if signup_activated in [
+            SIGNUP_WITH_AUTH,
+            SIGNUP_WITH_NO_AUTH,
+            SIGNUP_PLATFORM_ADMIN_ONLY,
+        ]:
             api.add_resource(
                 SignUpEndpoint, CONDITIONAL_ENDPOINTS["signup"], endpoint="signup"
             )

--- a/cornflow-server/cornflow/app.py
+++ b/cornflow-server/cornflow/app.py
@@ -85,6 +85,46 @@ def _check_secret_keys(app):
             )
 
 
+def _check_session_windows(app):
+    """
+    Warns when the session windows are configured in a way that would log out
+    users who are actively working.
+
+    Activity is only recorded when the client exchanges the refresh token, and
+    a client only does that once its access token has expired. So an
+    inactivity window that is not longer than the access-token lifetime closes
+    the session of an active user: by the time the client refreshes, the
+    window has already elapsed. The same applies to an absolute cap shorter
+    than the inactivity window, which would make the window unreachable.
+
+    These are misconfigurations rather than security weaknesses (they are
+    stricter, not laxer), so they are reported and not clamped.
+
+    :param app: the Flask application being created
+    """
+    if int(app.config.get("REFRESH_TOKEN_ENABLED", 1)) != 1:
+        return
+    access = int(app.config.get("ACCESS_TOKEN_DURATION_MINUTES", 15))
+    inactivity = int(app.config.get("REFRESH_TOKEN_INACTIVITY_MINUTES", 30))
+    absolute_minutes = int(app.config.get("REFRESH_TOKEN_ABSOLUTE_HOURS", 12)) * 60
+    if inactivity <= access:
+        app.logger.warning(
+            f"REFRESH_TOKEN_INACTIVITY_MINUTES ({inactivity}) is not greater "
+            f"than ACCESS_TOKEN_DURATION_MINUTES ({access}): users who are "
+            f"actively working will be logged out, because a client only "
+            f"refreshes its session once the access token has expired. Set "
+            f"the inactivity window above the access-token lifetime "
+            f"(defaults: 15 and 30)."
+        )
+    if absolute_minutes <= inactivity:
+        app.logger.warning(
+            f"REFRESH_TOKEN_ABSOLUTE_HOURS ({absolute_minutes // 60}h) is not "
+            f"longer than REFRESH_TOKEN_INACTIVITY_MINUTES ({inactivity} min): "
+            f"every session will end at the absolute cap and the inactivity "
+            f"window will never apply."
+        )
+
+
 def create_app(env_name="development", dataconn=None):
     """
 
@@ -103,6 +143,7 @@ def create_app(env_name="development", dataconn=None):
 
     app.config.from_object(app_config[env_name])
     _check_secret_keys(app)
+    _check_session_windows(app)
     # initialization for init_cornflow_service.py
     if dataconn is not None:
         app.config["SQLALCHEMY_DATABASE_URI"] = dataconn

--- a/cornflow-server/cornflow/cli/service.py
+++ b/cornflow-server/cornflow/cli/service.py
@@ -176,7 +176,13 @@ def _setup_environment_variables():
     # Cornflow app config
     os.environ.setdefault("cornflow_url", "http://cornflow:5000")
     os.environ["FLASK_APP"] = "cornflow.app"
-    os.environ["SECRET_KEY"] = os.getenv("FERNET_KEY", Fernet.generate_key().decode())
+    # Respect an operator-provided SECRET_KEY: it signs the tokens and the
+    # secrets encrypted at rest (TOTP) derive from it. FERNET_KEY stays as
+    # the fallback so deployments that never set SECRET_KEY keep the key
+    # their stored secrets were derived from after an upgrade.
+    os.environ.setdefault(
+        "SECRET_KEY", os.getenv("FERNET_KEY", Fernet.generate_key().decode())
+    )
 
     # Cornflow db defaults
     os.environ["DEFAULT_POSTGRES"] = "1"

--- a/cornflow-server/cornflow/cli/users.py
+++ b/cornflow-server/cornflow/cli/users.py
@@ -157,10 +157,11 @@ def unlock_user(username):
 
 @users.command(
     name="bi_token",
-    help="Generate a BI token for a user (valid for BI_TOKEN_DURATION_DAYS "
-    "days). Intended to be run inside the server with database access; no "
-    "further authentication is required because CLI access is already "
-    "privileged. Use it to (re)generate Power BI tokens.",
+    help="[DEPRECATED] Generate a BI token for a user (valid for "
+    "BI_TOKEN_DURATION_DAYS days). BI tokens are superseded by the read-only "
+    "personal API keys (users api_key --read-only), which are individually "
+    "revocable and get expiry warnings; this command is kept for backwards "
+    "compatibility and will be removed in a future release.",
 )
 @username
 def issue_bi_token(username):

--- a/cornflow-server/cornflow/cli/users.py
+++ b/cornflow-server/cornflow/cli/users.py
@@ -21,6 +21,16 @@ from cornflow.shared.exceptions import (
 )
 
 
+force_password_change = click.option(
+    "--force-password-change",
+    is_flag=True,
+    default=False,
+    help="Mark the password as single-use: the user must change it on first "
+    "login. Meant for provisioning accounts for other people. Not available "
+    "for service users, which are exempt from rotation.",
+)
+
+
 @click.group(name="users", help="Commands to manage the users")
 def users():
     """
@@ -60,11 +70,18 @@ def create_service_user(username, password, email, verbose):
 @password
 @email
 @verbose
-def create_viewer_user(username, password, email, verbose):
+@force_password_change
+def create_viewer_user(username, password, email, verbose, force_password_change):
     app = get_app()
     with app.app_context():
         create_user_with_role(
-            username, email, password, "viewer user", VIEWER_ROLE, verbose=verbose
+            username,
+            email,
+            password,
+            "viewer user",
+            VIEWER_ROLE,
+            verbose=verbose,
+            force_password_change=force_password_change,
         )
 
 
@@ -73,7 +90,8 @@ def create_viewer_user(username, password, email, verbose):
 @password
 @email
 @verbose
-def create_platform_admin_user(username, password, email, verbose):
+@force_password_change
+def create_platform_admin_user(username, password, email, verbose, force_password_change):
     app = get_app()
     with app.app_context():
         create_user_with_role(
@@ -83,6 +101,7 @@ def create_platform_admin_user(username, password, email, verbose):
             "platform administrator",
             PLATFORM_ADMIN_ROLE,
             verbose=verbose,
+            force_password_change=force_password_change,
         )
 
 
@@ -95,7 +114,8 @@ def create_platform_admin_user(username, password, email, verbose):
 @password
 @email
 @verbose
-def create_platform_viewer_user(username, password, email, verbose):
+@force_password_change
+def create_platform_viewer_user(username, password, email, verbose, force_password_change):
     app = get_app()
     with app.app_context():
         create_user_with_role(
@@ -105,6 +125,7 @@ def create_platform_viewer_user(username, password, email, verbose):
             "platform viewer",
             PLATFORM_VIEWER_ROLE,
             verbose=verbose,
+            force_password_change=force_password_change,
         )
 
 
@@ -117,7 +138,8 @@ def create_platform_viewer_user(username, password, email, verbose):
 @password
 @email
 @verbose
-def create_platform_planner_user(username, password, email, verbose):
+@force_password_change
+def create_platform_planner_user(username, password, email, verbose, force_password_change):
     app = get_app()
     with app.app_context():
         create_user_with_role(
@@ -127,6 +149,7 @@ def create_platform_planner_user(username, password, email, verbose):
             "platform planner",
             PLATFORM_PLANNER_ROLE,
             verbose=verbose,
+            force_password_change=force_password_change,
         )
 
 

--- a/cornflow-server/cornflow/commands/users.py
+++ b/cornflow-server/cornflow/commands/users.py
@@ -1,5 +1,11 @@
 def create_user_with_role(
-    username, email, password, role_name, role, verbose: bool = False
+    username,
+    email,
+    password,
+    role_name,
+    role,
+    verbose: bool = False,
+    force_password_change: bool = False,
 ):
     from cornflow.models import UserModel, UserRoleModel, RoleModel
     from cornflow.shared.exceptions import InvalidCredentials
@@ -8,7 +14,12 @@ def create_user_with_role(
     user = UserModel.get_one_user_by_username(username)
 
     if user is None:
-        data = dict(username=username, email=email, password=password)
+        data = dict(
+            username=username,
+            email=email,
+            password=password,
+            pwd_change_required=force_password_change,
+        )
         try:
             user = UserModel(data=data)
         except InvalidCredentials as err:

--- a/cornflow-server/cornflow/commands/users.py
+++ b/cornflow-server/cornflow/commands/users.py
@@ -32,6 +32,16 @@ def create_user_with_role(
         user.save()
         user_role = UserRoleModel({"user_id": user.id, "role_id": role})
         user_role.save()
+        from cornflow.shared.audit import audit
+
+        audit(
+            "user.created",
+            actor="cli",
+            target_id=user.id,
+            target=username,
+            source="cli",
+            role_id=role,
+        )
         if verbose:
             current_app.logger.info(
                 f"User {username} is created and assigned {role_name} role"

--- a/cornflow-server/cornflow/config.py
+++ b/cornflow-server/cornflow/config.py
@@ -212,6 +212,10 @@ class DefaultConfig(object):
     # Require a fresh TOTP (step-up) when an MFA-enabled user generates an
     # API key through the API/UI. The CLI path is exempt (machine access).
     API_KEY_STEPUP_TOTP = int(os.getenv("API_KEY_STEPUP_TOTP", 1))
+    # Granting a platform role through the API asks the acting administrator
+    # for a fresh TOTP code (same step-up as generating an API key): a stolen
+    # session token alone can not mint internal accounts
+    PLATFORM_ROLE_STEPUP_TOTP = int(os.getenv("PLATFORM_ROLE_STEPUP_TOTP", 1))
     # Rotation grace window in minutes: after generating a new API key the
     # previous one keeps working for this long, so a key wired into running
     # automation can be replaced without a gap (generate, then redeploy).

--- a/cornflow-server/cornflow/endpoints/api_key.py
+++ b/cornflow-server/cornflow/endpoints/api_key.py
@@ -98,17 +98,29 @@ class UserApiKeyEndpoint(BaseMetaResource):
                 )
 
         scope = kwargs.get("scope") or API_KEY_SCOPE_FULL
+        superseded = user.api_key_issued_at is not None
         user.rotate_api_key(scope=scope)
         api_key = self.auth_class.generate_api_key(user.id, scope=scope)
         expires_at = user.api_key_expires_at()
         current_app.logger.info(
             f"User {user.id} generated a personal API key (scope {scope})"
         )
+        # The previous key (if any) is superseded by this rotation: leave its
+        # own trace instead of letting it disappear silently. It may outlive
+        # this moment by the rotation grace window.
+        if superseded:
+            audit(
+                "apikey.revoked",
+                actor_id=user.id,
+                actor=user.username,
+                source="api",
+                reason="superseded",
+            )
         audit(
             "apikey.issued",
             actor_id=user.id,
             actor=user.username,
-            source="ui",
+            source="api",
             scope=scope,
             expires_at=expires_at,
         )
@@ -128,5 +140,5 @@ class UserApiKeyEndpoint(BaseMetaResource):
         user = self.get_user()
         user.revoke_api_keys()
         current_app.logger.info(f"User {user.id} revoked their personal API key")
-        audit("apikey.revoked", actor_id=user.id, actor=user.username, source="ui")
+        audit("apikey.revoked", actor_id=user.id, actor=user.username, source="api")
         return {"message": "The API key has been revoked"}, 200

--- a/cornflow-server/cornflow/endpoints/refresh.py
+++ b/cornflow-server/cornflow/endpoints/refresh.py
@@ -48,8 +48,9 @@ class RefreshTokenEndpoint(BaseMetaResource):
         :rtype: Tuple(dict, integer)
         """
         body = request.get_json(silent=True) or {}
+        # The session.refreshed audit event is emitted by the auth layer, which
+        # is where the user behind the token is resolved
         result = self.auth_class.consume_refresh_token(body.get("refresh_token"))
-        audit("session.refreshed", actor_id=result.get("id"))
         return result, 200
 
 
@@ -72,6 +73,12 @@ class LogoutEndpoint(BaseMetaResource):
         :rtype: Tuple(dict, integer)
         """
         body = request.get_json(silent=True) or {}
-        self.auth_class.revoke_session(body.get("refresh_token"))
-        audit("session.logout")
+        user = self.auth_class.revoke_session(body.get("refresh_token"))
+        # A logout carries no session credential, so the actor is taken from
+        # the session that was closed (None when there was nothing to close)
+        audit(
+            "session.logout",
+            actor_id=getattr(user, "id", None),
+            actor=getattr(user, "username", None),
+        )
         return {"message": "The session has been closed"}, 200

--- a/cornflow-server/cornflow/endpoints/signup.py
+++ b/cornflow-server/cornflow/endpoints/signup.py
@@ -3,7 +3,7 @@ External endpoint for the user to signup
 """
 
 # Import from libraries
-from flask import current_app
+from flask import current_app, g
 from flask_apispec import use_kwargs, doc
 
 # Import from internal modules
@@ -92,6 +92,21 @@ class SignUpEndpoint(BaseMetaResource):
                 error="Email already in use, please supply another email address",
                 log_txt="Error while user tries to sign up. Email already in use.",
             )
+
+        # When the signup is performed by an authenticated administrator
+        # (SIGNUP_ACTIVATED with auth) the password is known by someone other
+        # than the account owner, so it is single-use: the user must change
+        # it on first login. Self-registration (open signup) is not marked -
+        # the owner chose the password themselves. The config is checked
+        # besides g.user because g lives on the application context and can
+        # carry the actor of a previous request when the context outlives the
+        # request (as under flask_testing); with auth required, g.user was
+        # necessarily set by this request's authentication.
+        signup_requires_auth = (
+            int(current_app.config["SIGNUP_ACTIVATED"]) != SIGNUP_WITH_NO_AUTH
+        )
+        if signup_requires_auth and getattr(g, "user", None) is not None:
+            user.pwd_change_required = True
 
         user.save()
 

--- a/cornflow-server/cornflow/endpoints/signup.py
+++ b/cornflow-server/cornflow/endpoints/signup.py
@@ -10,11 +10,13 @@ from flask_apispec import use_kwargs, doc
 from cornflow.endpoints.meta_resource import BaseMetaResource
 from cornflow.models import PermissionsDAG, UserRoleModel, UserModel
 from cornflow.schemas.user import SignupRequest
+from cornflow.shared.audit import audit
 from cornflow.shared.authentication import Auth, authenticate
 from cornflow.shared.const import (
     ADMIN_ROLE,
     AUTH_LDAP,
     AUTH_OID,
+    SIGNUP_PLATFORM_ADMIN_ONLY,
     SIGNUP_WITH_NO_AUTH,
     TOKEN_PURPOSE_MFA_SETUP,
 )
@@ -22,6 +24,7 @@ from cornflow.shared.exceptions import (
     EndpointNotImplemented,
     InvalidCredentials,
     InvalidUsage,
+    NoPermission,
 )
 
 
@@ -79,6 +82,24 @@ class SignUpEndpoint(BaseMetaResource):
                 err, log_txt="Error while user tries to sign up. " + err
             )
 
+        # Restricted provisioning: with SIGNUP_PLATFORM_ADMIN_ONLY only a
+        # platform administrator can create accounts, so compromising a
+        # client admin is not enough to quietly provision new ones. The
+        # authentication necessarily ran on this request in this mode, so
+        # g.user is this request's actor.
+        if (
+            int(current_app.config["SIGNUP_ACTIVATED"])
+            == SIGNUP_PLATFORM_ADMIN_ONLY
+        ):
+            actor = getattr(g, "user", None)
+            if actor is None or not actor.is_platform_admin():
+                raise NoPermission(
+                    error="Only a platform administrator can create users on "
+                    "this deployment",
+                    log_txt="Error while a user tries to sign up. User "
+                    "creation is restricted to platform administrators.",
+                )
+
         user = self.data_model(kwargs)
 
         if user.check_username_in_use():
@@ -115,6 +136,19 @@ class SignUpEndpoint(BaseMetaResource):
         )
 
         user_role.save()
+
+        # Account creations are security-relevant (a quietly provisioned
+        # account is a persistence vector): leave who created whom
+        actor = getattr(g, "user", None) if signup_requires_auth else None
+        audit(
+            "user.created",
+            actor_id=actor.id if actor is not None else None,
+            actor=actor.username if actor is not None else "self-signup",
+            target_id=user.id,
+            target=user.username,
+            source="api",
+            role_id=int(current_app.config["DEFAULT_ROLE"]),
+        )
 
         try:
             if int(current_app.config.get("MFA_REQUIRED", 0)) == 1:

--- a/cornflow-server/cornflow/endpoints/user_role.py
+++ b/cornflow-server/cornflow/endpoints/user_role.py
@@ -9,7 +9,7 @@ from flask_apispec import doc, marshal_with, use_kwargs
 
 # Import from internal modules
 from cornflow.endpoints.meta_resource import BaseMetaResource
-from cornflow.models import UserRoleModel
+from cornflow.models import RoleModel, UserModel, UserRoleModel
 from cornflow.schemas.user_role import UserRoleRequest, UserRoleResponse
 from cornflow.shared.audit import audit
 from cornflow.shared.authentication import Auth, authenticate
@@ -19,6 +19,18 @@ from cornflow.shared.exceptions import (
     NoPermission,
     ObjectAlreadyExists,
 )
+
+
+def _role_name_of(role_id):
+    """Readable role name for the audit trail (falls back to None)."""
+    role = RoleModel.get_one_object(idx=role_id)
+    return role.name if role is not None else None
+
+
+def _username_of(user_id):
+    """Readable username for the audit trail (falls back to None)."""
+    user = UserModel.get_one_user(user_id)
+    return user.username if user is not None else None
 
 
 class UserRoleListEndpoint(BaseMetaResource):
@@ -109,7 +121,9 @@ class UserRoleListEndpoint(BaseMetaResource):
             audit(
                 "role.granted",
                 target_id=kwargs.get("user_id"),
+                target=_username_of(kwargs.get("user_id")),
                 role_id=kwargs.get("role_id"),
+                role=_role_name_of(kwargs.get("role_id")),
             )
             return self.activate_detail(**kwargs)
         elif UserRoleModel.check_if_role_assigned(**kwargs):
@@ -126,7 +140,9 @@ class UserRoleListEndpoint(BaseMetaResource):
             audit(
                 "role.granted",
                 target_id=kwargs.get("user_id"),
+                target=_username_of(kwargs.get("user_id")),
                 role_id=kwargs.get("role_id"),
+                role=_role_name_of(kwargs.get("role_id")),
             )
             return self.post_list(kwargs, trace_field="admin_id")
 
@@ -197,5 +213,11 @@ class UserRoleDetailEndpoint(BaseMetaResource):
         current_app.logger.info(
             f"User {self.get_user()} deletes user role assignment for user {user_id} and role {role_id}"
         )
-        audit("role.revoked", target_id=user_id, role_id=role_id)
+        audit(
+            "role.revoked",
+            target_id=user_id,
+            target=_username_of(user_id),
+            role_id=role_id,
+            role=_role_name_of(role_id),
+        )
         return self.delete_detail(user_id=user_id, role_id=role_id)

--- a/cornflow-server/cornflow/endpoints/user_role.py
+++ b/cornflow-server/cornflow/endpoints/user_role.py
@@ -15,6 +15,7 @@ from cornflow.shared.audit import audit
 from cornflow.shared.authentication import Auth, authenticate
 from cornflow.shared.const import ADMIN_ROLE, AUTH_LDAP, PLATFORM_ROLES
 from cornflow.shared.exceptions import (
+    InvalidCredentials,
     EndpointNotImplemented,
     NoPermission,
     ObjectAlreadyExists,
@@ -98,6 +99,10 @@ class UserRoleListEndpoint(BaseMetaResource):
                 + err,
             )
 
+        # The code never reaches the model: it only proves the actor's
+        # presence for the step-up below
+        totp_code = kwargs.pop("totp_code", None)
+
         # Platform roles are internal: only a platform administrator can
         # grant them. Without this check a client admin could escalate
         # themselves (or anyone) into the platform side.
@@ -112,6 +117,25 @@ class UserRoleListEndpoint(BaseMetaResource):
                 f"{kwargs.get('user_id')}. Only platform administrators can "
                 f"grant platform roles.",
             )
+
+        # Granting a platform role mints an internal account: a stolen admin
+        # session must not be enough, so the acting administrator confirms
+        # with a fresh TOTP code (same step-up as generating an API key).
+        # Only enforceable when the actor has MFA enrolled.
+        if kwargs.get("role_id") in PLATFORM_ROLES:
+            step_up = (
+                int(current_app.config.get("PLATFORM_ROLE_STEPUP_TOTP", 1)) == 1
+            )
+            actor = self.get_user()
+            if step_up and actor.mfa_enabled:
+                if not totp_code or not actor.check_totp_code(totp_code):
+                    raise InvalidCredentials(
+                        "A valid two-factor authentication code is required "
+                        "to grant a platform role",
+                        log_txt=f"Error while user {actor} tries to grant "
+                        f"platform role {kwargs.get('role_id')}. The step-up "
+                        f"TOTP code is missing or invalid.",
+                    )
 
         # Check if the assignation is disabled, or it does exist
         if UserRoleModel.check_if_role_assigned_disabled(**kwargs):

--- a/cornflow-server/cornflow/models/base_data_model.py
+++ b/cornflow-server/cornflow/models/base_data_model.py
@@ -54,6 +54,34 @@ def _hide_platform_objects(query, cls, user):
     )
 
 
+def apply_visibility(query, cls, user):
+    """
+    Applies the visibility rules of a data object to a query: the per-user
+    restriction (USER_ACCESS_ALL_OBJECTS) and the platform/client isolation.
+
+    Every listing or lookup of data objects must go through here. Some models
+    re-implement their own listing query for performance (deferred columns,
+    extra filters), so keeping the rules in a single function is what stops
+    the paths from drifting apart: that drift is exactly how the executions of
+    a platform user stayed visible to a client admin in the list while the
+    detail view already answered 404.
+
+    :param query: the query being built
+    :param cls: the model class being queried
+    :param user: the user performing the query (None for internal calls)
+    :return: the query with the visibility rules applied
+    """
+    user_access = int(current_app.config["USER_ACCESS_ALL_OBJECTS"])
+    if (
+        user is not None
+        and not user.is_admin()
+        and not user.is_service_user()
+        and user_access == USER_ACCESS_ALL_OBJECTS_NO
+    ):
+        query = query.filter(cls.user_id == user.id)
+    return _hide_platform_objects(query, cls, user)
+
+
 class BaseDataModel(TraceAttributesModel):
     """ """
 
@@ -122,17 +150,7 @@ class BaseDataModel(TraceAttributesModel):
         query = cls.query.filter(cls.deleted_at == None)
         if options:
             query = query.options(*options)
-        user_access = int(current_app.config["USER_ACCESS_ALL_OBJECTS"])
-        if (
-            user is not None
-            and not user.is_admin()
-            and not user.is_service_user()
-            and user_access == 0
-        ):
-            query = query.filter(cls.user_id == user.id)
-
-        # Client users never see the objects of internal (platform) users
-        query = _hide_platform_objects(query, cls, user)
+        query = apply_visibility(query, cls, user)
 
         if schema:
             query = query.filter(cls.schema == schema)
@@ -169,8 +187,5 @@ class BaseDataModel(TraceAttributesModel):
         if options:
             query = query.options(*options)
         query = query.filter_by(id=idx, deleted_at=None)
-        if not user.is_admin() and not user.is_service_user() and user_access == USER_ACCESS_ALL_OBJECTS_NO:
-            query = query.filter_by(user_id=user.id)
-        # Client users never see the objects of internal (platform) users
-        query = _hide_platform_objects(query, cls, user)
+        query = apply_visibility(query, cls, user)
         return query.first()

--- a/cornflow-server/cornflow/models/base_data_model.py
+++ b/cornflow-server/cornflow/models/base_data_model.py
@@ -35,6 +35,12 @@ def _hide_platform_objects(query, cls, user):
         return query
     if not int(current_app.config.get("PLATFORM_DATA_ISOLATION", 1)):
         return query
+    # Service accounts act on behalf of every user: airflow must be able to
+    # read a platform user's instance to solve it (found in UAT 12.1, where
+    # the executions of a platform user never left the queue because the
+    # service account could not see their data and every task got a 404)
+    if user.is_service_user():
+        return query
     # Imported here to avoid a circular import at module load
     from cornflow.models.user_role import UserRoleModel
 

--- a/cornflow-server/cornflow/models/execution.py
+++ b/cornflow-server/cornflow/models/execution.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import defer
 from sqlalchemy.sql.expression import false
 
 # Imports from internal modules
-from cornflow.models.base_data_model import BaseDataModel
+from cornflow.models.base_data_model import BaseDataModel, apply_visibility
 from cornflow.shared import db
 from cornflow.shared.const import (
     DEFAULT_EXECUTION_CODE,
@@ -204,14 +204,9 @@ class ExecutionModel(BaseDataModel):
         :rtype: list(:class:`BaseDataModel`)
         """
         query = cls.query.options(defer(cls.data), defer(cls.checks)).filter(cls.deleted_at == None)
-        user_access = int(current_app.config["USER_ACCESS_ALL_OBJECTS"])
-        if (
-            user is not None
-            and not user.is_admin()
-            and not user.is_service_user()
-            and user_access == 0
-        ):
-            query = query.filter(cls.user_id == user.id)
+        # Shared with the base model so the list and the detail view can not
+        # disagree on who may see what
+        query = apply_visibility(query, cls, user)
 
         if schema:
             query = query.filter(cls.schema == schema)

--- a/cornflow-server/cornflow/schemas/user_role.py
+++ b/cornflow-server/cornflow/schemas/user_role.py
@@ -13,6 +13,9 @@ class UserRoleRequest(Schema):
 
     user_id = fields.Int()
     role_id = fields.Int()
+    # Fresh TOTP code of the ACTING administrator, required (when the step-up
+    # is enabled and the actor has MFA) to grant a platform role
+    totp_code = fields.Str(required=False, load_default=None)
 
 
 class UserRoleResponse(UserRoleRequest):

--- a/cornflow-server/cornflow/shared/authentication/auth.py
+++ b/cornflow-server/cornflow/shared/authentication/auth.py
@@ -520,6 +520,12 @@ class Auth:
                 f"session expired (inactivity or absolute cap).",
             )
         session.rotate()
+        audit(
+            "session.refreshed",
+            actor_id=user.id,
+            actor=user.username,
+            session_id=session.session_id,
+        )
         return {
             "token": Auth.generate_access_token(user.id, session=session),
             "refresh_token": Auth.generate_refresh_token(user.id, session),
@@ -532,19 +538,29 @@ class Auth:
         Revokes the session behind a refresh token (logout). Idempotent: an
         invalid, expired or already-revoked token is a no-op.
 
+        Returns the owner of the closed session so the caller can attribute the
+        event: a logout is not authenticated (the client only sends the refresh
+        token), so without this the audit record would say when and from where
+        but never who.
+
         :param str refresh_token: the refresh token whose session to revoke
+        :return: the user whose session was closed, or None when there was
+          nothing to close
+        :rtype: :class:`UserModel` or None
         """
         if not refresh_token:
-            return
+            return None
         try:
             payload = Auth.decode_token(refresh_token)
         except InvalidCredentials:
-            return
+            return None
         if not isinstance(payload, dict) or payload.get("type") != TOKEN_TYPE_REFRESH:
-            return
+            return None
         session = SessionModel.get_active(payload.get("sid"))
-        if session is not None:
-            session.revoke()
+        if session is None:
+            return None
+        session.revoke()
+        return UserModel.get_one_user(session.user_id)
 
     @staticmethod
     def generate_api_key(user_id: int = None, scope: str = None) -> str:
@@ -621,7 +637,11 @@ class Auth:
             raise InvalidCredentials(
                 "The token has expired, please login again",
                 log_txt="Error while trying to decode token. The token has expired.",
-                status_code=400,
+                # 401 and not 400: an expired credential is an authentication
+                # failure, and it is the status every client (the web app, the
+                # cornflow-client library) uses to decide to renew the session
+                # instead of surfacing the error.
+                status_code=401,
             )
         except (
             jwt.InvalidSignatureError,
@@ -642,7 +662,7 @@ class Auth:
                     raise InvalidCredentials(
                         "The token has expired, please login again",
                         log_txt="Error while trying to decode OIDC token. The token has expired.",
-                        status_code=400,
+                        status_code=401,
                     )
                 except (
                     jwt.InvalidTokenError,

--- a/cornflow-server/cornflow/shared/authentication/auth.py
+++ b/cornflow-server/cornflow/shared/authentication/auth.py
@@ -341,13 +341,19 @@ class Auth:
         )
 
     @staticmethod
-    def generate_access_token(user_id: int = None) -> str:
+    def generate_access_token(user_id: int = None, session=None) -> str:
         """
         Generates a short-lived access token (ACCESS_TOKEN_DURATION_MINUTES)
         carrying the token-version claim. It is the credential sent on every
         request; the client renews it via the refresh endpoint.
 
+        When it belongs to a stored session the token also carries its id
+        ("sid"), so revoking that session (logout, refresh-token reuse
+        detection) invalidates the access tokens already in circulation
+        instead of letting them live until their own expiry.
+
         :param int user_id: user id to generate the token for
+        :param session: the :class:`SessionModel` the token belongs to, if any
         :return: the generated access token
         :rtype: str
         """
@@ -373,6 +379,8 @@ class Auth:
             "tv": user.token_version or 0,
             "type": TOKEN_TYPE_ACCESS,
         }
+        if session is not None:
+            payload["sid"] = session.session_id
         return jwt.encode(
             payload, current_app.config["SECRET_TOKEN_KEY"], algorithm="HS256"
         )
@@ -432,7 +440,7 @@ class Auth:
             return {"token": Auth.generate_token(user.id)}
         session = SessionModel.create_for_user(user)
         return {
-            "token": Auth.generate_access_token(user.id),
+            "token": Auth.generate_access_token(user.id, session=session),
             "refresh_token": Auth.generate_refresh_token(user.id, session),
         }
 
@@ -513,7 +521,7 @@ class Auth:
             )
         session.rotate()
         return {
-            "token": Auth.generate_access_token(user.id),
+            "token": Auth.generate_access_token(user.id, session=session),
             "refresh_token": Auth.generate_refresh_token(user.id, session),
             "id": user.id,
         }
@@ -755,8 +763,55 @@ class Auth:
             )
 
         self._check_token_version(user, data)
+        self._check_session_state(user, data)
 
         return user, data
+
+    @staticmethod
+    def _check_session_state(user, payload):
+        """
+        Rejects an access token whose backing session is gone, revoked or past
+        its absolute lifetime.
+
+        Access tokens are short-lived but stateless, so without this check a
+        revoked session would keep granting access until the token expired on
+        its own (up to ACCESS_TOKEN_DURATION_MINUTES): logging out, or
+        detecting the reuse of a refresh token, would stop the renewal but not
+        the access already in circulation.
+
+        Only the absolute cap is enforced here, never the inactivity window:
+        activity is recorded when the client refreshes, which an active client
+        does at least once per access-token lifetime (the window is always
+        longer than that lifetime). Checking inactivity here would log out a
+        user who is actively making requests.
+
+        Tokens issued before sessions were bound (no "sid" claim) are left to
+        the token-version check alone, so upgrading a deployment does not log
+        everybody out.
+
+        :param user: the user the token belongs to
+        :param dict payload: the decoded token payload
+        """
+        if not isinstance(payload, dict):
+            return
+        session_id = payload.get("sid")
+        if not session_id:
+            return
+        session = SessionModel.get_active(session_id)
+        if session is None:
+            raise InvalidCredentials(
+                "The session has been closed, please log in again",
+                status_code=401,
+                log_txt=f"Error while user {user.id} authenticates. The session "
+                f"backing the access token is revoked or no longer exists.",
+            )
+        if session.is_expired():
+            raise InvalidCredentials(
+                "The session has expired, please log in again",
+                status_code=401,
+                log_txt=f"Error while user {user.id} authenticates. The session "
+                f"backing the access token reached its absolute lifetime.",
+            )
 
     def _check_token_version(self, user, payload):
         """

--- a/cornflow-server/cornflow/shared/const.py
+++ b/cornflow-server/cornflow/shared/const.py
@@ -156,9 +156,13 @@ AIRFLOW_TO_STATE_MAP = dict(
 # NO_SIGNUP: no signup endpoint
 # SIGNUP_WITH_NO_AUTH: signup endpoint with no auth
 # SIGNUP_WITH_AUTH: signup endpoint with auth
+# SIGNUP_PLATFORM_ADMIN_ONLY: signup endpoint with auth, restricted to
+# platform administrators (a compromised client admin can not quietly
+# provision new accounts)
 NO_SIGNUP = 0
 SIGNUP_WITH_NO_AUTH = 1
 SIGNUP_WITH_AUTH = 2
+SIGNUP_PLATFORM_ADMIN_ONLY = 3
 
 DATABRICKS_TO_STATE_MAP = dict(
     BLOCKED=EXEC_STATE_QUEUED,

--- a/cornflow-server/cornflow/tests/custom_test_case.py
+++ b/cornflow-server/cornflow/tests/custom_test_case.py
@@ -1049,7 +1049,9 @@ class LoginTestCases:
                 },
             )
 
-            self.assertEqual(400, response.status_code)
+            # 401: an expired credential is an authentication failure, and it
+            # is the status that tells a client to renew the session
+            self.assertEqual(401, response.status_code)
             self.assertEqual(
                 "The token has expired, please login again", response.json["error"]
             )

--- a/cornflow-server/cornflow/tests/unit/test_cli.py
+++ b/cornflow-server/cornflow/tests/unit/test_cli.py
@@ -494,6 +494,56 @@ class CLITests(TestCase):
         self.assertEqual(user.roles, {1: "viewer"})
         self.assertFalse(user.is_service_user())
 
+    def test_viewer_user_command_not_marked_by_default(self):
+        runner = CliRunner()
+        self.test_roles_init_command()
+        result = runner.invoke(
+            cli,
+            [
+                "users",
+                "create",
+                "viewer",
+                "-u",
+                "plainuser",
+                "-p",
+                "Kx9#tR2m!Qw7Zp",
+                "-e",
+                "plainuser@test.org",
+            ],
+        )
+        self.assertEqual(result.exit_code, 0)
+        user = UserModel.get_one_user_by_email("plainuser@test.org")
+        self.assertFalse(user.pwd_change_required)
+
+    def test_viewer_user_command_force_password_change(self):
+        runner = CliRunner()
+        self.test_roles_init_command()
+        result = runner.invoke(
+            cli,
+            [
+                "users",
+                "create",
+                "viewer",
+                "-u",
+                "provisioned",
+                "-p",
+                "Kx9#tR2m!Qw7Zp",
+                "-e",
+                "provisioned@test.org",
+                "--force-password-change",
+            ],
+        )
+        self.assertEqual(result.exit_code, 0)
+        user = UserModel.get_one_user_by_email("provisioned@test.org")
+        self.assertTrue(user.pwd_change_required)
+
+    def test_service_user_command_has_no_force_flag(self):
+        # Service users are exempt from rotation: the flag must not exist
+        runner = CliRunner()
+        result = runner.invoke(cli, ["users", "create", "service", "--help"])
+        self.assertEqual(result.exit_code, 0)
+        self.assertNotIn("--force-password-change", result.output)
+
     def test_generate_token(self):
         runner = CliRunner()
 

--- a/cornflow-server/cornflow/tests/unit/test_log_in.py
+++ b/cornflow-server/cornflow/tests/unit/test_log_in.py
@@ -415,7 +415,9 @@ class TestLogInOpenAuth(CustomTestCase):
             },
         )
 
-        self.assertEqual(400, response.status_code)
+        # 401: an expired credential is an authentication failure, and it is
+        # what tells a client to renew the session instead of failing
+        self.assertEqual(401, response.status_code)
         self.assertEqual(
             "The token has expired, please login again", response.json["error"]
         )

--- a/cornflow-server/cornflow/tests/unit/test_platform_isolation.py
+++ b/cornflow-server/cornflow/tests/unit/test_platform_isolation.py
@@ -11,6 +11,8 @@ users:
 
 import json
 
+import pyotp
+
 from flask import current_app
 from flask_testing import TestCase
 
@@ -30,7 +32,13 @@ from cornflow.shared.const import (
     SERVICE_ROLE,
 )
 from cornflow.shared.exceptions import ConfigurationError
-from cornflow.tests.const import INSTANCE_PATH, INSTANCE_URL, LOGIN_URL, SIGNUP_URL
+from cornflow.tests.const import (
+    INSTANCE_PATH,
+    INSTANCE_URL,
+    LOGIN_URL,
+    SIGNUP_URL,
+    USER_ROLE_URL,
+)
 
 STRONG_PASSWORD = "Kx9#tR2m!Qw7Zp"
 JSON_HEADER = {"Content-Type": "application/json"}
@@ -382,3 +390,77 @@ class TestReservedRoleIds(TestCase):
         message = str(ctx.exception)
         self.assertIn("supervisor", message)
         self.assertIn("950", message)
+
+
+class TestPlatformRoleStepUp(TestCase, _RoleUserMixin):
+    """
+    Granting a platform role through the API requires a fresh TOTP code from
+    the acting administrator (when they have MFA enrolled): a stolen session
+    token alone must not be able to mint internal accounts.
+    """
+
+    def create_app(self):
+        return create_app("testing")
+
+    def setUp(self):
+        db.create_all()
+        access_init_command(verbose=False)
+        register_deployed_dags_command_test(verbose=False)
+        self.admin_token, self.admin_id = self.user_with_role(
+            "stepupadmin", "stepupadmin@test.com", PLATFORM_ADMIN_ROLE
+        )
+        _, self.target_id = self.user_with_role(
+            "stepuptarget", "stepuptarget@test.com", PLANNER_ROLE
+        )
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+
+    def grant(self, role_id, totp_code=None):
+        payload = {"user_id": self.target_id, "role_id": role_id}
+        if totp_code is not None:
+            payload["totp_code"] = totp_code
+        return self.client.post(
+            USER_ROLE_URL,
+            data=json.dumps(payload),
+            headers=auth_header(self.admin_token),
+        )
+
+    def enable_mfa(self):
+        secret = pyotp.random_base32()
+        from cornflow.models import UserModel
+
+        user = UserModel.get_one_user(self.admin_id)
+        user.set_totp_secret(secret)
+        user.mfa_enabled = True
+        user.save()
+        return secret
+
+    def test_without_mfa_no_step_up_applies(self):
+        response = self.grant(PLATFORM_VIEWER_ROLE)
+        self.assertEqual(201, response.status_code)
+
+    def test_with_mfa_a_code_is_required(self):
+        self.enable_mfa()
+        response = self.grant(PLATFORM_VIEWER_ROLE)
+        self.assertEqual(400, response.status_code)
+
+    def test_with_mfa_a_wrong_code_is_rejected(self):
+        self.enable_mfa()
+        response = self.grant(PLATFORM_VIEWER_ROLE, totp_code="000000")
+        self.assertEqual(400, response.status_code)
+
+    def test_with_mfa_a_valid_code_grants(self):
+        secret = self.enable_mfa()
+        response = self.grant(
+            PLATFORM_VIEWER_ROLE, totp_code=pyotp.TOTP(secret).now()
+        )
+        self.assertEqual(201, response.status_code)
+
+    def test_client_roles_need_no_step_up(self):
+        # the step-up protects the platform side only: ordinary role grants
+        # keep working without a code even with MFA enabled
+        self.enable_mfa()
+        response = self.grant(ADMIN_ROLE)
+        self.assertEqual(201, response.status_code)

--- a/cornflow-server/cornflow/tests/unit/test_platform_isolation.py
+++ b/cornflow-server/cornflow/tests/unit/test_platform_isolation.py
@@ -232,6 +232,21 @@ class TestPlatformDataIsolation(TestCase, _RoleUserMixin):
             platform_execution, self.list_executions(platform_admin_token)
         )
 
+    def test_service_account_sees_platform_data(self):
+        # UAT 12.1: airflow (a client-side service account) must read the
+        # instance of a platform user to solve their execution; the isolation
+        # must not apply to service accounts, which act on behalf of everyone
+        service_token, _ = self.user_with_role(
+            "svcisolation", "svcisolation@test.com", SERVICE_ROLE
+        )
+        platform_instance = self.create_instance(self.platform_token)
+        response = self.client.get(
+            f"{INSTANCE_URL}{platform_instance}/",
+            headers=auth_header(service_token),
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertIn(platform_instance, self.list_instances(service_token))
+
     def test_isolation_can_be_disabled(self):
         platform_instance = self.create_instance(self.platform_token)
         current_app.config["PLATFORM_DATA_ISOLATION"] = 0

--- a/cornflow-server/cornflow/tests/unit/test_platform_isolation.py
+++ b/cornflow-server/cornflow/tests/unit/test_platform_isolation.py
@@ -19,7 +19,7 @@ from cornflow.commands.access import access_init_command
 from cornflow.commands.auxiliar import check_reserved_role_ids
 from cornflow.commands.dag import register_deployed_dags_command_test
 from cornflow.commands.permissions import register_dag_permissions_command
-from cornflow.models import InstanceModel, RoleModel, UserRoleModel
+from cornflow.models import ExecutionModel, InstanceModel, RoleModel, UserRoleModel
 from cornflow.shared import db
 from cornflow.shared.const import (
     ADMIN_ROLE,
@@ -161,6 +161,76 @@ class TestPlatformDataIsolation(TestCase, _RoleUserMixin):
         visible = self.list_instances(self.platform_token)
         self.assertIn(own_instance, visible)
         self.assertNotIn(client_instance, visible)
+
+    def make_execution(self, token, owner_id):
+        """Creates an execution owned by `owner_id` over a new instance."""
+        instance_id = self.create_instance(token)
+        execution = ExecutionModel(
+            {
+                "user_id": owner_id,
+                "instance_id": instance_id,
+                "name": "platform execution",
+                "description": "",
+                "schema": "solve_model_dag",
+                "config": {"solver": "cbc"},
+            }
+        )
+        execution.save()
+        return execution.id
+
+    def list_executions(self, token):
+        response = self.client.get("/execution/", headers=auth_header(token))
+        self.assertEqual(200, response.status_code)
+        return [item["id"] for item in response.json]
+
+    def test_client_admin_does_not_list_platform_executions(self):
+        # UAT 7.12: the executions list is built by ExecutionModel with its own
+        # query, so it has to apply the same isolation as the detail view —
+        # otherwise the object shows up in the list and 404s when opened
+        platform_execution = self.make_execution(
+            self.platform_token, self.platform_id
+        )
+        client_execution = self.make_execution(self.client_token, self.client_id)
+
+        visible = self.list_executions(self.admin_token)
+        self.assertIn(client_execution, visible)
+        self.assertNotIn(platform_execution, visible)
+
+    def test_client_user_does_not_list_platform_executions(self):
+        platform_execution = self.make_execution(
+            self.platform_token, self.platform_id
+        )
+        own_execution = self.make_execution(self.client_token, self.client_id)
+
+        visible = self.list_executions(self.client_token)
+        self.assertIn(own_execution, visible)
+        self.assertNotIn(platform_execution, visible)
+
+    def test_the_execution_list_and_detail_agree(self):
+        # the two paths must never disagree: whatever the list hides, the
+        # detail must refuse, and the other way round
+        platform_execution = self.make_execution(
+            self.platform_token, self.platform_id
+        )
+        self.assertNotIn(
+            platform_execution, self.list_executions(self.admin_token)
+        )
+        detail = self.client.get(
+            f"/execution/{platform_execution}/",
+            headers=auth_header(self.admin_token),
+        )
+        self.assertEqual(404, detail.status_code)
+
+    def test_platform_admin_lists_platform_executions(self):
+        platform_admin_token, _ = self.user_with_role(
+            "padminexec", "padminexec@test.com", PLATFORM_ADMIN_ROLE
+        )
+        platform_execution = self.make_execution(
+            self.platform_token, self.platform_id
+        )
+        self.assertIn(
+            platform_execution, self.list_executions(platform_admin_token)
+        )
 
     def test_isolation_can_be_disabled(self):
         platform_instance = self.create_instance(self.platform_token)

--- a/cornflow-server/cornflow/tests/unit/test_refresh_token.py
+++ b/cornflow-server/cornflow/tests/unit/test_refresh_token.py
@@ -174,6 +174,102 @@ class TestRefreshTokenFlow(TestCase):
         new_refresh = self.refresh(refresh_token).json["refresh_token"]
         self.assertEqual(200, self.refresh(new_refresh).status_code)
 
+    # -- the access token dies with its session ----------------------------
+
+    def test_reuse_detection_kills_the_access_token_in_circulation(self):
+        # UAT 6.5: revoking the session on reuse detection must also stop the
+        # access tokens already issued, not only the renewal
+        login = self.login().json
+        rotated = self.refresh(login["refresh_token"]).json
+        # replaying the superseded refresh token revokes the session
+        self.assertEqual(401, self.refresh(login["refresh_token"]).status_code)
+        # neither the access token minted by the refresh...
+        self.assertEqual(
+            401,
+            self.client.get(
+                f"{USER_URL}{self.user_id}/", headers=auth_header(rotated["token"])
+            ).status_code,
+        )
+        # ...nor the one issued at login keep working
+        self.assertEqual(
+            401,
+            self.client.get(
+                f"{USER_URL}{self.user_id}/", headers=auth_header(login["token"])
+            ).status_code,
+        )
+
+    def test_logout_kills_the_access_token_in_circulation(self):
+        # same hole on the logout path: clicking "log out" must end access now
+        login = self.login().json
+        self.assertEqual(200, self.logout(login["refresh_token"]).status_code)
+        response = self.client.get(
+            f"{USER_URL}{self.user_id}/", headers=auth_header(login["token"])
+        )
+        self.assertEqual(401, response.status_code)
+
+    def test_absolute_cap_kills_the_access_token(self):
+        login = self.login().json
+        session = self._session()
+        session.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        db.session.add(session)
+        db.session.commit()
+        self.assertEqual(
+            401,
+            self.client.get(
+                f"{USER_URL}{self.user_id}/", headers=auth_header(login["token"])
+            ).status_code,
+        )
+
+    def test_revoking_one_session_leaves_the_others_alive(self):
+        # each login is an independent session: closing one must not close the
+        # rest (only a global event such as a password change does that)
+        first = self.login().json
+        second = self.login().json
+        self.logout(first["refresh_token"])
+        self.assertEqual(
+            401,
+            self.client.get(
+                f"{USER_URL}{self.user_id}/", headers=auth_header(first["token"])
+            ).status_code,
+        )
+        self.assertEqual(
+            200,
+            self.client.get(
+                f"{USER_URL}{self.user_id}/", headers=auth_header(second["token"])
+            ).status_code,
+        )
+
+    def test_inactivity_does_not_break_an_active_access_token(self):
+        # the session-state check must NOT enforce the inactivity window, or a
+        # user making requests without refreshing would be logged out
+        login = self.login().json
+        session = self._session()
+        window = int(current_app.config["REFRESH_TOKEN_INACTIVITY_MINUTES"])
+        session.last_activity_at = datetime.now(timezone.utc) - timedelta(
+            minutes=window + 5
+        )
+        db.session.add(session)
+        db.session.commit()
+        # the access token still works (it is the refresh that would fail)
+        self.assertEqual(
+            200,
+            self.client.get(
+                f"{USER_URL}{self.user_id}/", headers=auth_header(login["token"])
+            ).status_code,
+        )
+        self.assertEqual(401, self.refresh(login["refresh_token"]).status_code)
+
+    def test_legacy_token_without_session_still_works(self):
+        # tokens issued before sessions were bound carry no "sid": they must
+        # keep working so upgrading a deployment does not log everybody out
+        from cornflow.shared.authentication import Auth
+
+        legacy = Auth.generate_token(self.user_id)
+        response = self.client.get(
+            f"{USER_URL}{self.user_id}/", headers=auth_header(legacy)
+        )
+        self.assertEqual(200, response.status_code)
+
     # -- revocation --------------------------------------------------------
 
     def test_logout_revokes_session(self):

--- a/cornflow-server/cornflow/tests/unit/test_refresh_token.py
+++ b/cornflow-server/cornflow/tests/unit/test_refresh_token.py
@@ -6,12 +6,14 @@ refusal to use a refresh token on a normal endpoint.
 """
 
 import json
+import logging
+import unittest
 from datetime import datetime, timedelta, timezone
 
 from flask import current_app
 from flask_testing import TestCase
 
-from cornflow.app import create_app
+from cornflow.app import _check_session_windows, create_app
 from cornflow.commands.access import access_init_command
 from cornflow.commands.dag import register_deployed_dags_command_test
 from cornflow.commands.permissions import register_dag_permissions_command
@@ -399,3 +401,81 @@ class TestRefreshTokenFlow(TestCase):
         self.assertEqual("session.reuse_detected", events[0]["event"])
         self.assertEqual(self.user_id, events[0]["actor_id"])
         self.assertEqual("revoked", events[0]["outcome"])
+
+
+class TestSessionWindowSanityCheck(unittest.TestCase):
+    """
+    The inactivity window must be longer than the access-token lifetime: a
+    client only refreshes once its access token has expired, so a shorter
+    window would log out users who are actively working. The application
+    reports the misconfiguration at startup (it is stricter, not laxer, so it
+    is not clamped).
+    """
+
+    def _warnings(self, **config):
+        app = create_app("testing")
+        app.config.update(config)
+        records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                records.append(record.getMessage())
+
+        handler = _Capture()
+        app.logger.addHandler(handler)
+        try:
+            _check_session_windows(app)
+        finally:
+            app.logger.removeHandler(handler)
+        return records
+
+    def test_no_warning_with_the_defaults(self):
+        self.assertEqual(
+            [],
+            self._warnings(
+                ACCESS_TOKEN_DURATION_MINUTES=15,
+                REFRESH_TOKEN_INACTIVITY_MINUTES=30,
+                REFRESH_TOKEN_ABSOLUTE_HOURS=12,
+            ),
+        )
+
+    def test_warns_when_the_window_is_not_longer_than_the_access_token(self):
+        warnings = self._warnings(
+            ACCESS_TOKEN_DURATION_MINUTES=15,
+            REFRESH_TOKEN_INACTIVITY_MINUTES=10,
+            REFRESH_TOKEN_ABSOLUTE_HOURS=12,
+        )
+        self.assertTrue(
+            any("REFRESH_TOKEN_INACTIVITY_MINUTES" in w for w in warnings),
+            msg=f"expected a warning, got {warnings}",
+        )
+
+    def test_warns_when_the_window_equals_the_access_token(self):
+        warnings = self._warnings(
+            ACCESS_TOKEN_DURATION_MINUTES=15,
+            REFRESH_TOKEN_INACTIVITY_MINUTES=15,
+            REFRESH_TOKEN_ABSOLUTE_HOURS=12,
+        )
+        self.assertTrue(any("actively working" in w for w in warnings))
+
+    def test_warns_when_the_absolute_cap_swallows_the_window(self):
+        warnings = self._warnings(
+            ACCESS_TOKEN_DURATION_MINUTES=15,
+            REFRESH_TOKEN_INACTIVITY_MINUTES=120,
+            REFRESH_TOKEN_ABSOLUTE_HOURS=1,
+        )
+        self.assertTrue(
+            any("REFRESH_TOKEN_ABSOLUTE_HOURS" in w for w in warnings),
+            msg=f"expected a warning, got {warnings}",
+        )
+
+    def test_silent_when_refresh_sessions_are_disabled(self):
+        self.assertEqual(
+            [],
+            self._warnings(
+                REFRESH_TOKEN_ENABLED=0,
+                ACCESS_TOKEN_DURATION_MINUTES=15,
+                REFRESH_TOKEN_INACTIVITY_MINUTES=1,
+                REFRESH_TOKEN_ABSOLUTE_HOURS=12,
+            ),
+        )

--- a/cornflow-server/cornflow/tests/unit/test_security_hardening.py
+++ b/cornflow-server/cornflow/tests/unit/test_security_hardening.py
@@ -975,6 +975,7 @@ class TestLoginLockout(TestCase):
             headers=JSON_HEADER,
         )
 
+
     def test_lockout_after_max_attempts(self):
         # A wrong password always returns the same generic error (no
         # enumeration), even on the attempt that trips the lock
@@ -1818,6 +1819,27 @@ class TestAuditLogging(TestCase):
         self.audit_logger.removeHandler(self.capture)
         db.session.remove()
         db.drop_all()
+
+    def test_user_created_event(self):
+        # A quietly provisioned account is a persistence vector: every account
+        # creation leaves an audit event saying who created whom
+        response = self.client.post(
+            SIGNUP_URL,
+            data=json.dumps(
+                {
+                    "username": "createdbyaudit",
+                    "email": "createdbyaudit@test.com",
+                    "password": STRONG_PASSWORD,
+                }
+            ),
+            headers=JSON_HEADER,
+        )
+        self.assertEqual(201, response.status_code)
+        events = self.capture.by_event("user.created")
+        self.assertEqual(1, len(events))
+        self.assertEqual("createdbyaudit", events[0].get("target"))
+        # open signup: nobody else created it
+        self.assertEqual("self-signup", events[0].get("actor"))
 
     def log_in(self, password):
         return self.client.post(

--- a/cornflow-server/cornflow/tests/unit/test_sign_up.py
+++ b/cornflow-server/cornflow/tests/unit/test_sign_up.py
@@ -19,7 +19,15 @@ from cornflow.commands.dag import register_deployed_dags_command_test
 from cornflow.models import UserModel, UserRoleModel, ViewModel, PermissionViewRoleModel
 from cornflow.shared import db
 from cornflow.shared.authentication import Auth
-from cornflow.shared.const import PLANNER_ROLE, ADMIN_ROLE, POST_ACTION, NO_SIGNUP, SIGNUP_WITH_AUTH
+from cornflow.shared.const import (
+    ADMIN_ROLE,
+    NO_SIGNUP,
+    PLANNER_ROLE,
+    PLATFORM_ADMIN_ROLE,
+    POST_ACTION,
+    SIGNUP_PLATFORM_ADMIN_ONLY,
+    SIGNUP_WITH_AUTH,
+)
 from cornflow.tests.const import SIGNUP_URL
 
 
@@ -324,3 +332,78 @@ class TestSignUpAuthenticated(TestCase):
         self.assertIsNotNone(
             post_permission, "Admin should have POST permission for signup endpoint"
         )
+
+
+class TestSignUpPlatformAdminOnly(TestCase):
+    """SIGNUP_ACTIVATED=SIGNUP_PLATFORM_ADMIN_ONLY: only platform admins provision accounts."""
+
+    def create_app(self):
+        with patch(
+            "cornflow.config.Testing.SIGNUP_ACTIVATED", SIGNUP_PLATFORM_ADMIN_ONLY
+        ):
+            app = create_app("testing")
+        return app
+
+    def setUp(self):
+        db.create_all()
+        access_init_command(verbose=False)
+        register_deployed_dags_command_test(verbose=False)
+        self.data = {
+            "username": "testname",
+            "email": "test@test.com",
+            "password": "Kx9#tR2m!Qw7Zp",
+        }
+        self.platform_admin = UserModel(
+            {
+                "username": "platadmin",
+                "email": "platadmin@test.com",
+                "password": "Am9!cV4b#Ls6Qe",
+            }
+        )
+        self.platform_admin.save()
+        UserRoleModel(
+            {"user_id": self.platform_admin.id, "role_id": PLATFORM_ADMIN_ROLE}
+        ).save()
+        self.client_admin = UserModel(
+            {
+                "username": "clientadmin",
+                "email": "clientadmin@test.com",
+                "password": "Rg3$hJ7u!Pw9Bn",
+            }
+        )
+        self.client_admin.save()
+        UserRoleModel(
+            {"user_id": self.client_admin.id, "role_id": ADMIN_ROLE}
+        ).save()
+
+    def tearDown(self):
+        db.session.remove()
+        db.drop_all()
+
+    def signup_as(self, user):
+        headers = {"Content-Type": "application/json"}
+        if user is not None:
+            headers["Authorization"] = f"Bearer {Auth().generate_token(user.id)}"
+        return self.client.post(
+            SIGNUP_URL,
+            data=json.dumps(self.data),
+            follow_redirects=True,
+            headers=headers,
+        )
+
+    def test_platform_admin_can_provision(self):
+        response = self.signup_as(self.platform_admin)
+        self.assertEqual(201, response.status_code)
+        # the password is known by the admin: single-use
+        user = UserModel.get_one_user(response.json["id"])
+        self.assertTrue(user.pwd_change_required)
+
+    def test_client_admin_can_not_provision(self):
+        response = self.signup_as(self.client_admin)
+        self.assertEqual(403, response.status_code)
+        self.assertIsNone(UserModel.get_one_user_by_username("testname"))
+
+    def test_unauthenticated_can_not_provision(self):
+        response = self.signup_as(None)
+        self.assertGreaterEqual(response.status_code, 400)
+        self.assertIsNone(UserModel.get_one_user_by_username("testname"))

--- a/cornflow-server/cornflow/tests/unit/test_sign_up.py
+++ b/cornflow-server/cornflow/tests/unit/test_sign_up.py
@@ -43,6 +43,18 @@ class TestSignUp(TestCase):
         db.session.remove()
         db.drop_all()
 
+    def test_self_signup_password_is_not_single_use(self):
+        # The owner chose the password themselves: no forced change
+        response = self.client.post(
+            SIGNUP_URL,
+            data=json.dumps(self.data),
+            follow_redirects=True,
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(201, response.status_code)
+        user = UserModel.get_one_user(response.json["id"])
+        self.assertFalse(user.pwd_change_required)
+
     def test_successful_signup(self):
         payload = self.data
 
@@ -189,6 +201,23 @@ class TestSignUpAuthenticated(TestCase):
         """Helper method to get authentication token for a user"""
         auth = Auth()
         return auth.generate_token(user.id)
+
+    def test_admin_provisioned_password_is_single_use(self):
+        # An administrator knows the password they typed: the account must
+        # change it on first login (same reasoning as an admin reset)
+        admin_token = self.get_auth_token(self.admin_user)
+        response = self.client.post(
+            SIGNUP_URL,
+            data=json.dumps(self.data),
+            follow_redirects=True,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {admin_token}",
+            },
+        )
+        self.assertEqual(201, response.status_code)
+        user = UserModel.get_one_user(response.json["id"])
+        self.assertTrue(user.pwd_change_required)
 
     def test_authenticated_signup_admin_can_register(self):
         """Test that admin users can register new users"""

--- a/libs/client/cornflow_client/raw_cornflow_client.py
+++ b/libs/client/cornflow_client/raw_cornflow_client.py
@@ -8,6 +8,33 @@ from urllib.parse import urljoin
 import requests
 
 
+
+def _is_expired_token(response) -> bool:
+    """
+    Whether a response says the access token has expired and the call is worth
+    retrying after renewing the session.
+
+    A current server answers 401. Older ones answered 400 with the expiry
+    message, so that is accepted too: otherwise a script talking to a server
+    that has not been updated would fail instead of renewing.
+
+    :param response: the requests response to inspect
+    :rtype: bool
+    """
+    status = getattr(response, "status_code", None)
+    if status == 401:
+        return True
+    if status != 400:
+        return False
+    try:
+        body = response.json()
+    except Exception:
+        return False
+    if not isinstance(body, dict):
+        return False
+    return "expired" in str(body.get("error", "")).lower()
+
+
 class RawCornFlow(object):
     """
     Base class to access cornflow-server
@@ -27,14 +54,11 @@ class RawCornFlow(object):
             if not self.token:
                 raise CornFlowApiError("Need to login first!")
             response = func(self, *args, **kwargs)
-            # Interactive sessions use a short-lived access token: on a 401
-            # renew it once with the stored refresh token and retry the call
-            # transparently, so long-running scripts keep working. API-key
-            # sessions have no refresh token and are returned as-is.
-            if (
-                getattr(response, "status_code", None) == 401
-                and self.refresh_token
-            ):
+            # Interactive sessions use a short-lived access token: when it has
+            # expired, renew it once with the stored refresh token and retry
+            # the call transparently, so long-running scripts keep working.
+            # API-key sessions have no refresh token and are returned as-is.
+            if self.refresh_token and _is_expired_token(response):
                 refresh_response = self.refresh()
                 if refresh_response.status_code == 200:
                     response = func(self, *args, **kwargs)

--- a/libs/client/cornflow_client/tests/integration/test_cornflow_integration.py
+++ b/libs/client/cornflow_client/tests/integration/test_cornflow_integration.py
@@ -61,11 +61,15 @@ class TestCornflowClientUser(TestCase):
     def test_refresh_and_logout(self):
         # the interactive login returned a refresh token
         self.assertIsNotNone(self.client.refresh_token)
-        old_token = self.client.token
-        # refresh rotates the access + refresh token and keeps the session
+        old_refresh = self.client.refresh_token
+        # refresh rotates the refresh token (a fresh unique jti every time)
+        # and keeps the session. The ACCESS token is deliberately not
+        # compared: its claims have second resolution, so a refresh landing
+        # in the same second as the login mints a byte-identical (and equally
+        # valid) token and the comparison flakes.
         result = self.client.refresh()
         self.assertIn("token", result)
-        self.assertNotEqual(old_token, self.client.token)
+        self.assertNotEqual(old_refresh, self.client.refresh_token)
         # the new access token works on an authenticated endpoint
         self.assertEqual("user", self.client.get_one_user(self.user_id)["username"])
         # logout revokes the session: a further refresh is no longer possible

--- a/libs/client/cornflow_client/tests/unit/test_client_refresh.py
+++ b/libs/client/cornflow_client/tests/unit/test_client_refresh.py
@@ -82,6 +82,38 @@ class TestRawClientRefresh(TestCase):
         retry_headers = req.call_args[1]["headers"]
         self.assertEqual("Bearer access-2", retry_headers["Authorization"])
 
+    def test_expired_token_reported_as_400_is_also_renewed(self):
+        # UAT 12.5: the server used to answer 400 (not 401) when the access
+        # token expired, so a retry that only looked at 401 never fired and the
+        # script died after ~15 minutes. Servers that still do must work.
+        self.login({"token": "access-1", "refresh_token": "refresh-1", "id": 1})
+        with mock.patch(
+            "cornflow_client.raw_cornflow_client.requests.request",
+            side_effect=[
+                _response(400, {"error": "The token has expired, please login again"}),
+                _response(200, [{"id": "instance-1"}]),
+            ],
+        ) as req, mock.patch(
+            "cornflow_client.raw_cornflow_client.requests.post",
+            return_value=_response(
+                200, {"token": "access-2", "refresh_token": "refresh-2", "id": 1}
+            ),
+        ):
+            response = self.client.get_all_instances()
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(2, req.call_count)
+
+    def test_an_ordinary_400_is_not_retried(self):
+        # only an expiry justifies renewing: a plain bad request must surface
+        self.login({"token": "access-1", "refresh_token": "refresh-1", "id": 1})
+        with mock.patch(
+            "cornflow_client.raw_cornflow_client.requests.request",
+            return_value=_response(400, {"error": "Invalid payload"}),
+        ) as req:
+            response = self.client.get_all_instances()
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(1, req.call_count)
+
     def test_401_without_refresh_token_is_returned_as_is(self):
         # API-key style session: no refresh token, the 401 is not retried
         self.client.set_api_key("an-api-key")


### PR DESCRIPTION
# Correcciones de las pruebas de aceptación y refuerzos de aprovisionamiento

Correcciones surgidas de la primera pasada de las pruebas de aceptación y
tres refuerzos de aprovisionamiento acordados después. Siete commits, cada
uno con sus pruebas; la suite completa pasa (541 tests).

## Correcciones (hallazgos de las pruebas)

- **Revocar una sesión corta también los tokens de acceso en circulación**:
  el token lleva ahora el identificador de sesión (`sid`) y el estado se
  comprueba en cada petición; reutilización de refresco, logout y tope
  absoluto expulsan al instante (antes el acceso seguía vivo hasta 15 min).
  Los tokens antiguos sin `sid` siguen funcionando.
- **Una credencial caducada responde 401** (antes 400): es lo que dispara la
  renovación en los clientes; `cornflow-client` acepta además el 400 antiguo
  por compatibilidad.
- **El aislamiento plataforma/cliente se aplica también al listado de
  ejecuciones** (tenía su propia consulta y divergía del detalle); las reglas
  quedan centralizadas en `apply_visibility()`.
- **Las cuentas de servicio quedan exentas del aislamiento**: airflow debe
  poder leer los datos de un usuario de plataforma para resolver sus
  ejecuciones (se quedaban en cola con 404 por tarea).
- **Aviso al arrancar cuando las ventanas de sesión son incoherentes**
  (inactividad ≤ vida del token de acceso, o tope absoluto ≤ ventana).
- **Arranque**: se respeta la `SECRET_KEY` del operador (antes se
  sobrescribía siempre con `FERNET_KEY`, que queda como respaldo). Ojo en
  despliegues con ambas variables distintas: ver notas de la release.

## Refuerzos de aprovisionamiento

- **Contraseña de un solo uso al aprovisionar**: el alta hecha por un
  administrador autenticado vía `/signup/` marca `change_password` (el admin
  conoce la contraseña); el autorregistro no marca. En la CLI,
  `--force-password-change` en los comandos de creación (nunca en el usuario
  de servicio).
- **Nuevo modo `SIGNUP_ACTIVATED=3`**: solo los administradores de
  plataforma pueden crear usuarios (por defecto sigue el modo 2).
- **Evento `user.created`** en toda alta (API, autorregistro y CLI), con
  quién creó a quién.
- **Refuerzo TOTP al conceder roles de plataforma por API**
  (`PLATFORM_ROLE_STEPUP_TOTP`, activo por defecto): un token de sesión
  robado no basta para crear cuentas internas.

## Pulido de auditoría

- `role.granted`/`role.revoked` incluyen el nombre del rol y del usuario.
- Regenerar una clave de API deja `apikey.revoked` con `reason: superseded`
  para la clave sustituida; `source` refleja el canal real (`api`/`cli`).
- La ayuda de `users bi_token` indica `[DEPRECATED]` y remite a las claves
  de solo lectura.
